### PR TITLE
fix crash occurring when no headset is connected

### DIFF
--- a/LucidGloves/include/ControllerDriver.h
+++ b/LucidGloves/include/ControllerDriver.h
@@ -94,6 +94,8 @@ public:
 private:
 	uint32_t m_driverId;
 
+	bool m_hasActivated;
+
 	vr::VRInputComponentHandle_t m_skeletalComponentHandle{};
 	vr::VRInputComponentHandle_t m_inputComponentHandles[8]{};
 


### PR DESCRIPTION
For some reason, SteamVR doesn't give any info to devices on whether they are still active if it doesn't detect a headset. This is kind of a work around for making sure that we have actually activated a device, but it might be sensible to investigate more cleaner solutions.