### PR TITLE
GCC compiler errors

### DIFF
--- a/src/DeviceDriver/KnuckleDriver.cpp
+++ b/src/DeviceDriver/KnuckleDriver.cpp
@@ -8,7 +8,7 @@ namespace knuckleDevice {
 	const char* c_deviceManufacturer = "FluidControlObject";
 }
 
-static const enum ComponentIndex : int {
+enum ComponentIndex : int {
 	SYSTEM_CLICK,
 	SYSTEM_TOUCH,
 	TRIGGER_CLICK,

--- a/src/DeviceDriver/LucidGloveDriver.cpp
+++ b/src/DeviceDriver/LucidGloveDriver.cpp
@@ -12,7 +12,7 @@ namespace lucidGlove {
 
 }
 
-static const enum ComponentIndex : int {
+enum ComponentIndex : int {
 	COMP_JOY_X = 0,
 	COMP_JOY_Y = 1,
 	COMP_JOY_BTN = 2,

--- a/src/DriverLog.cpp
+++ b/src/DriverLog.cpp
@@ -7,10 +7,6 @@
 
 static vr::IVRDriverLog* s_pLogFile = NULL;
 
-#if !defined( WIN32)
-#define vsnprintf_s vsnprintf
-#endif
-
 bool InitDriverLog(vr::IVRDriverLog* pDriverLog) {
 	if (s_pLogFile)
 		return false;
@@ -24,7 +20,7 @@ void CleanupDriverLog() {
 
 static void DriverLogVarArgs(const char* pMsgFormat, va_list args) {
 	char buf[1024];
-	vsnprintf_s(buf, sizeof(buf), pMsgFormat, args);
+    vsnprintf(buf, sizeof(buf), pMsgFormat, args);
 
 	if (s_pLogFile)
 		s_pLogFile->Log(buf);


### PR DESCRIPTION
This PR fixes compiling with gcc, where there were incorrect decalarations of enums, which weren't picked up by msvc.

#65