### PR TITLE
Bugfix btserial disconnect

### DIFF
--- a/src/Communication/BTSerialCommunicationManager.cpp
+++ b/src/Communication/BTSerialCommunicationManager.cpp
@@ -104,6 +104,11 @@ void BTSerialCommunicationManager::Disconnect() {
 
 
 		//Disconnect
+		if (!shutdown(m_btClientSocket, 2)) {
+			DebugDriverLog("Could not disconnect socket from ESP32. Error %ld", WSAGetLastError());
+		}
+		else
+			DebugDriverLog("Disconnected from socket successfully.");
 	}
 }
 //May want to get a heartbeat here instead?

--- a/src/Communication/BTSerialCommunicationManager.cpp
+++ b/src/Communication/BTSerialCommunicationManager.cpp
@@ -104,7 +104,7 @@ void BTSerialCommunicationManager::Disconnect() {
 
 
 		//Disconnect
-		if (!shutdown(m_btClientSocket, 2)) {
+		if (shutdown(m_btClientSocket, 2) == SOCKET_ERROR) {
 			DebugDriverLog("Could not disconnect socket from ESP32. Error %ld", WSAGetLastError());
 		}
 		else


### PR DESCRIPTION
Disconnects the windows socket when shutting down the driver. May prevent issues with repeated startups.