### PR TITLE
Fix mingw link errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ add_library("${OPENGLOVE_PROJECT}" SHARED "${HEADERS}" "${SOURCES}")
 target_include_directories("${OPENGLOVE_PROJECT}" PUBLIC "${OPENVR_INCLUDE_DIR}")
 
 target_include_directories("${OPENGLOVE_PROJECT}" PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include/")
-target_link_libraries("${OPENGLOVE_PROJECT}" PUBLIC "${OPENVR_LIB}")
+target_link_libraries("${OPENGLOVE_PROJECT}" PUBLIC "${OPENVR_LIB}" wsock32.lib ws2_32.lib Bthprops.lib)
 
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/include" PREFIX "Header Files" FILES ${HEADERS})
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/src" PREFIX "Source Files" FILES ${SOURCES})

--- a/include/Communication/BTSerialCommunicationManager.h
+++ b/include/Communication/BTSerialCommunicationManager.h
@@ -15,13 +15,7 @@
 #include <Ws2bth.h>
 #include <BluetoothAPIs.h>
 
-#ifdef _WIN32
-	#pragma comment(lib, "Ws2_32.lib")
-	#pragma comment(lib, "Bthprops.lib")
-#endif
-
 #define ARDUINO_WAIT_TIME 1000
-
 class BTSerialCommunicationManager : public ICommunicationManager {
 public:
 	BTSerialCommunicationManager(const VRBTSerialConfiguration_t& configuration, std::unique_ptr<IEncodingManager> encodingManager);

--- a/include/ControllerPose.h
+++ b/include/ControllerPose.h
@@ -20,6 +20,6 @@ private:
 
 	std::string m_thisDeviceManufacturer;
 
-	bool ControllerPose::IsOtherRole(int32_t test);
+	bool IsOtherRole(int32_t test);
 
 };


### PR DESCRIPTION
The previous bluetooth implementation used msvc comment pragma to link the required windows libraries for bluetooth.

This PR changes this to link them in the cmake, as well as fix some incorrect syntax which msvc didn't pick up on.