### PR TITLE
Alphabetic Encoding Manager

### DIFF
--- a/include/DeviceConfiguration.h
+++ b/include/DeviceConfiguration.h
@@ -15,6 +15,7 @@ enum VRCommunicationProtocol {
 
 enum VREncodingProtocol {
     LEGACY = 0,
+    ALPHA = 1,
 };
 
 enum VRDeviceDriver {

--- a/include/DeviceProvider.h
+++ b/include/DeviceProvider.h
@@ -9,8 +9,8 @@
 #include "DriverLog.h"
 
 #include "Communication/CommunicationManager.h"
-#include "Communication/SerialCommunicationManager.h"
-#include "Communication/BTSerialCommunicationManager.h"
+
+#include "Encode/EncodingManager.h"
 
 #include "DeviceDriver/DeviceDriver.h"
 

--- a/include/DeviceProvider.h
+++ b/include/DeviceProvider.h
@@ -12,10 +12,6 @@
 #include "Communication/SerialCommunicationManager.h"
 #include "Communication/BTSerialCommunicationManager.h"
 
-#include "Encode/EncodingManager.h"
-#include "Encode/LegacyEncodingManager.h"
-#include "Encode/AlphaEncodingManager.h"
-
 #include "DeviceDriver/DeviceDriver.h"
 
 

--- a/include/DeviceProvider.h
+++ b/include/DeviceProvider.h
@@ -14,6 +14,7 @@
 
 #include "Encode/EncodingManager.h"
 #include "Encode/LegacyEncodingManager.h"
+#include "Encode/AlphaEncodingManager.h"
 
 #include "DeviceDriver/DeviceDriver.h"
 

--- a/include/Encode/AlphaEncodingManager.h
+++ b/include/Encode/AlphaEncodingManager.h
@@ -2,8 +2,6 @@
 
 #include <Encode/EncodingManager.h>
 
-const char* alphabet = "ABCDE"; //expand as more letters are added to manager
-
 class AlphaEncodingManager : public IEncodingManager {
 public:
 	AlphaEncodingManager(float maxAnalogValue) : m_maxAnalogValue(maxAnalogValue){};
@@ -11,5 +9,8 @@ public:
 	//decode the given string into a VRCommData_t
 	VRCommData_t Decode(std::string input);
 private:
+    std::string getArgumentSubstring(std::string str, char del);
+
 	float m_maxAnalogValue;
+	const char* alphabet = "ABCDE";  // expand as more letters are added to manager
 };

--- a/include/Encode/AlphaEncodingManager.h
+++ b/include/Encode/AlphaEncodingManager.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Encode/EncodingManager.h>
+#include "Encode/EncodingManager.h"
 
 class AlphaEncodingManager : public IEncodingManager {
 public:
@@ -12,5 +12,5 @@ private:
     std::string getArgumentSubstring(std::string str, char del);
 
 	float m_maxAnalogValue;
-	const char* alphabet = "ABCDE";  // expand as more letters are added to manager
+	const char* alphabet = "ABCDEFGHIJKLM";  // expand as more letters are added to manager
 };

--- a/include/Encode/AlphaEncodingManager.h
+++ b/include/Encode/AlphaEncodingManager.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <Encode/EncodingManager.h>
+
+const char* alphabet = "ABCDE"; //expand as more letters are added to manager
+
+class AlphaEncodingManager : public IEncodingManager {
+public:
+	AlphaEncodingManager(float maxAnalogValue) : m_maxAnalogValue(maxAnalogValue){};
+	
+	//decode the given string into a VRCommData_t
+	VRCommData_t Decode(std::string input);
+private:
+	float m_maxAnalogValue;
+};

--- a/openglove/resources/settings/default.vrsettings
+++ b/openglove/resources/settings/default.vrsettings
@@ -6,7 +6,7 @@
     "right_enabled": true,
     "communication_protocol": 0, //title:Communication Method
     "device_driver": 1, //title:Device Driver Emulation
-    "encoding_protocol": 0 //title:Encoding Protocol
+    "encoding_protocol": 1 //title:Encoding Protocol
   },
   "device_lucidgloves":
   {

--- a/openglove/resources/settings/default.vrsettings
+++ b/openglove/resources/settings/default.vrsettings
@@ -49,16 +49,23 @@
     "left_port": "\\\\.\\COM4",
     "right_port": "\\\\.\\COM5"
   },
-	"communication_btserial": {
+  "communication_btserial": 
+  {
     "__type": "communication_protocol:1",
     "__title": "Bluetooth Serial",
-		"left_name": "lucidgloves-left",
-		"right_name": "lucidgloves-right"
-	},
+	"left_name": "lucidgloves-left",
+  	"right_name": "lucidgloves-right"
+  },
   "encoding_legacy":
   {
     "__type": "encoding_protocol: 0",
-    "__title": "Encoding Protocol",
+    "__title": "Legacy Encoding",
+    "max_analog_value": 1023
+  },
+  "encoding_alpha":
+  {
+    "__type": "encoding_protocol: 1",
+    "__title": "Alpha Protocol",
     "max_analog_value": 1023
   }
 }

--- a/src/DeviceProvider.cpp
+++ b/src/DeviceProvider.cpp
@@ -36,17 +36,20 @@ std::unique_ptr<IDeviceDriver> DeviceProvider::InstantiateDeviceDriver(VRDeviceC
 	std::unique_ptr<IEncodingManager> encodingManager;
 
 	bool isRightHand = configuration.role == vr::TrackedControllerRole_RightHand;
-    
-	const int maxAnalogValue = vr::VRSettings()->GetInt32("encoding_legacy", "max_analog_value");
 	switch (configuration.encodingProtocol) {
 	default:
 		DriverLog("No encoding protocol set. Using legacy.");
-	case VREncodingProtocol::LEGACY:
-		encodingManager = std::make_unique<LegacyEncodingManager>(maxAnalogValue);
-		break;
-    case VREncodingProtocol::ALPHA:
-        encodingManager = std::make_unique<AlphaEncodingManager>(maxAnalogValue);
-        break;
+    case VREncodingProtocol::LEGACY: {
+          const int maxAnalogValue =
+              vr::VRSettings()->GetInt32("encoding_legacy", "max_analog_value");
+          encodingManager = std::make_unique<LegacyEncodingManager>(maxAnalogValue);
+          break;
+        }
+    case VREncodingProtocol::ALPHA: {
+			const int maxAnalogValue = vr::VRSettings()->GetInt32("encoding_alpha", "max_analog_value");//
+			encodingManager = std::make_unique<AlphaEncodingManager>(maxAnalogValue);
+			break;
+		}
 	}
 
 

--- a/src/DeviceProvider.cpp
+++ b/src/DeviceProvider.cpp
@@ -6,6 +6,10 @@
 
 #include "Communication/SerialCommunicationManager.h"
 
+#include "Encode/EncodingManager.h"
+#include "Encode/LegacyEncodingManager.h"
+#include "Encode/AlphaEncodingManager.h"
+
 #include "Quaternion.h"
 
 vr::EVRInitError DeviceProvider::Init(vr::IVRDriverContext* pDriverContext) {

--- a/src/DeviceProvider.cpp
+++ b/src/DeviceProvider.cpp
@@ -36,14 +36,17 @@ std::unique_ptr<IDeviceDriver> DeviceProvider::InstantiateDeviceDriver(VRDeviceC
 	std::unique_ptr<IEncodingManager> encodingManager;
 
 	bool isRightHand = configuration.role == vr::TrackedControllerRole_RightHand;
-
+    
+	const int maxAnalogValue = vr::VRSettings()->GetInt32("encoding_legacy", "max_analog_value");
 	switch (configuration.encodingProtocol) {
 	default:
 		DriverLog("No encoding protocol set. Using legacy.");
 	case VREncodingProtocol::LEGACY:
-		const int maxAnalogValue = vr::VRSettings()->GetInt32("encoding_legacy", "max_analog_value");
 		encodingManager = std::make_unique<LegacyEncodingManager>(maxAnalogValue);
 		break;
+    case VREncodingProtocol::ALPHA:
+          encodingManager = std::make_unique<AlphaEncodingManager>(maxAnalogValue);
+          break;
 	}
 
 

--- a/src/DeviceProvider.cpp
+++ b/src/DeviceProvider.cpp
@@ -5,8 +5,8 @@
 #include "DeviceDriver/KnuckleDriver.h"
 
 #include "Communication/SerialCommunicationManager.h"
+#include "Communication/BTSerialCommunicationManager.h"
 
-#include "Encode/EncodingManager.h"
 #include "Encode/LegacyEncodingManager.h"
 #include "Encode/AlphaEncodingManager.h"
 

--- a/src/DeviceProvider.cpp
+++ b/src/DeviceProvider.cpp
@@ -45,8 +45,8 @@ std::unique_ptr<IDeviceDriver> DeviceProvider::InstantiateDeviceDriver(VRDeviceC
 		encodingManager = std::make_unique<LegacyEncodingManager>(maxAnalogValue);
 		break;
     case VREncodingProtocol::ALPHA:
-          encodingManager = std::make_unique<AlphaEncodingManager>(maxAnalogValue);
-          break;
+        encodingManager = std::make_unique<AlphaEncodingManager>(maxAnalogValue);
+        break;
 	}
 
 

--- a/src/Encode/AlphaEncodingManager.cpp
+++ b/src/Encode/AlphaEncodingManager.cpp
@@ -1,0 +1,74 @@
+#include <Encode/AlphaEncodingManager.h>
+
+#include <sstream>
+#include <vector>
+#include "DriverLog.h"
+
+/*
+*Alpha Encoding Manager Arguments:
+* A - Pinky Finger Position
+* B - Ring Finger Position
+* C - Middle Finger Position
+* D - Index Finger Position
+* E - Thumb Finger Position
+* F - Joystick X
+* G - Joystick Y
+* - Joystick click
+* - Trigger button
+* - A button
+* - B button
+* - Grab button
+* - Pinch button
+* - Calibration Reset button
+* 
+*/
+
+std::string getArgumentSubstring(std::string str, char del) { 
+    int start = str.find(del);
+    if (start == std::string::npos)
+        return NULL;
+    int end = str.find_first_of(alphabet, start + 1); //characters may not necessarily be in order, so end at any letter
+    return str.substr(start, end - start);
+}
+
+bool argValid(std::string str, char del) { return str.find(del) == std::string::npos; }
+
+VRCommData_t AlphaEncodingManager::Decode(std::string input) {
+
+    std::array<float, 5> flexion;
+    std::array<float, 5> splay;
+
+    if (argValid(input, 'A'))
+      flexion[0] = stof(getArgumentSubstring(input, 'A')) / m_maxAnalogValue;
+    if (argValid(input, 'B'))
+      flexion[1] = stof(getArgumentSubstring(input, 'B')) / m_maxAnalogValue;
+    if (argValid(input, 'C'))
+      flexion[2] = stof(getArgumentSubstring(input, 'C')) / m_maxAnalogValue;
+    if (argValid(input, 'D'))
+      flexion[3] = stof(getArgumentSubstring(input, 'D')) / m_maxAnalogValue;
+    if (argValid(input, 'E'))
+      flexion[4] = stof(getArgumentSubstring(input, 'E')) / m_maxAnalogValue;
+
+    float joyX;
+    float joyY;
+
+    if (argValid(input, 'F'))
+      joyX = stof(getArgumentSubstring(input, 'E')) / m_maxAnalogValue;
+    if (argValid(input, 'G'))
+      joyY = stof(getArgumentSubstring(input, 'G')) / m_maxAnalogValue;
+
+    VRCommData_t commData(
+        flexion,
+        splay,
+        joyX,
+        joyY,
+        tokens[VRCommDataInputPosition::JOY_BTN] == 1,
+        tokens[VRCommDataInputPosition::BTN_TRG] == 1,
+        tokens[VRCommDataInputPosition::BTN_A] == 1,
+        tokens[VRCommDataInputPosition::BTN_B] == 1,
+        tokens[VRCommDataInputPosition::GES_GRAB] == 1,
+        tokens[VRCommDataInputPosition::GES_PINCH] == 1
+    );
+
+    return commData;
+}

--- a/src/Encode/AlphaEncodingManager.cpp
+++ b/src/Encode/AlphaEncodingManager.cpp
@@ -39,6 +39,11 @@ VRCommData_t AlphaEncodingManager::Decode(std::string input) {
     std::array<float, 5> flexion;
     std::array<float, 5> splay;
 
+    for (int i = 0; i < 5; i++) { //splay tracking not yet supported
+        flexion[i] = -1; // 0.5;
+        splay[i] = 0.5;
+    }
+
     if (argValid(input, 'A'))
       flexion[0] = stof(getArgumentSubstring(input, 'A')) / m_maxAnalogValue;
     if (argValid(input, 'B'))
@@ -50,13 +55,13 @@ VRCommData_t AlphaEncodingManager::Decode(std::string input) {
     if (argValid(input, 'E'))
       flexion[4] = stof(getArgumentSubstring(input, 'E')) / m_maxAnalogValue;
 
-    float joyX;
-    float joyY;
+    float joyX = 0;
+    float joyY = 0;
 
     if (argValid(input, 'F'))
-      joyX = stof(getArgumentSubstring(input, 'E')) / m_maxAnalogValue;
+      joyX = 2 * stof(getArgumentSubstring(input, 'E')) / m_maxAnalogValue - 1;
     if (argValid(input, 'G'))
-      joyY = stof(getArgumentSubstring(input, 'G')) / m_maxAnalogValue;
+      joyY = 2 * stof(getArgumentSubstring(input, 'G')) / m_maxAnalogValue - 1;
 
     VRCommData_t commData(
         flexion,
@@ -68,7 +73,7 @@ VRCommData_t AlphaEncodingManager::Decode(std::string input) {
         argValid(input, 'J'), //A button
         argValid(input, 'K'), //B button
         argValid(input, 'L'), //grab
-        argValid(input, 'M') //pinch
+        argValid(input, 'M')  //pinch
     );
 
     return commData;

--- a/src/Encode/AlphaEncodingManager.cpp
+++ b/src/Encode/AlphaEncodingManager.cpp
@@ -32,7 +32,7 @@ std::string AlphaEncodingManager::getArgumentSubstring(std::string str, char del
     return str.substr(start, end - start);
 }
 
-bool argValid(std::string str, char del) { return str.find(del) == std::string::npos; }
+bool argValid(std::string str, char del) { return str.find(del) != std::string::npos; }
 
 VRCommData_t AlphaEncodingManager::Decode(std::string input) {
 
@@ -45,23 +45,28 @@ VRCommData_t AlphaEncodingManager::Decode(std::string input) {
     }
 
     if (argValid(input, 'A'))
-      flexion[0] = stof(getArgumentSubstring(input, 'A')) / m_maxAnalogValue;
+      flexion[0] =
+          stof(getArgumentSubstring(input, 'A').substr(1, std::string::npos)) / m_maxAnalogValue;
     if (argValid(input, 'B'))
-      flexion[1] = stof(getArgumentSubstring(input, 'B')) / m_maxAnalogValue;
+      flexion[1] =
+          stof(getArgumentSubstring(input, 'B').substr(1, std::string::npos)) / m_maxAnalogValue;
     if (argValid(input, 'C'))
-      flexion[2] = stof(getArgumentSubstring(input, 'C')) / m_maxAnalogValue;
+      flexion[2] =
+          stof(getArgumentSubstring(input, 'C').substr(1, std::string::npos)) / m_maxAnalogValue;
     if (argValid(input, 'D'))
-      flexion[3] = stof(getArgumentSubstring(input, 'D')) / m_maxAnalogValue;
+      flexion[3] =
+          stof(getArgumentSubstring(input, 'D').substr(1, std::string::npos)) / m_maxAnalogValue;
     if (argValid(input, 'E'))
-      flexion[4] = stof(getArgumentSubstring(input, 'E')) / m_maxAnalogValue;
+      flexion[4] =
+          stof(getArgumentSubstring(input, 'E').substr(1, std::string::npos)) / m_maxAnalogValue;
 
     float joyX = 0;
     float joyY = 0;
 
     if (argValid(input, 'F'))
-      joyX = 2 * stof(getArgumentSubstring(input, 'E')) / m_maxAnalogValue - 1;
+      joyX = 2 * stof(getArgumentSubstring(input, 'E').substr(1, std::string::npos)) / m_maxAnalogValue - 1;
     if (argValid(input, 'G'))
-      joyY = 2 * stof(getArgumentSubstring(input, 'G')) / m_maxAnalogValue - 1;
+      joyY = 2 * stof(getArgumentSubstring(input, 'G').substr(1, std::string::npos)) / m_maxAnalogValue - 1;
 
     VRCommData_t commData(
         flexion,

--- a/src/Encode/AlphaEncodingManager.cpp
+++ b/src/Encode/AlphaEncodingManager.cpp
@@ -24,7 +24,7 @@
 * 
 */
 
-std::string getArgumentSubstring(std::string str, char del) { 
+std::string AlphaEncodingManager::getArgumentSubstring(std::string str, char del) { 
     int start = str.find(del);
     if (start == std::string::npos)
         return NULL;

--- a/src/Encode/AlphaEncodingManager.cpp
+++ b/src/Encode/AlphaEncodingManager.cpp
@@ -4,7 +4,8 @@
 #include <vector>
 #include "DriverLog.h"
 
-/*
+
+/* Alpha encoding uses the wasted data in the delimiter from legacy to allow for optional arguments and redundancy over smaller packets
 *Alpha Encoding Manager Arguments:
 * A - Pinky Finger Position
 * B - Ring Finger Position
@@ -13,12 +14,12 @@
 * E - Thumb Finger Position
 * F - Joystick X
 * G - Joystick Y
-* - Joystick click
-* - Trigger button
-* - A button
-* - B button
-* - Grab button
-* - Pinch button
+* H - Joystick click
+* I - Trigger button
+* J - A button
+* K - B button
+* L - Grab button
+* M - Pinch button
 * - Calibration Reset button
 * 
 */
@@ -62,12 +63,12 @@ VRCommData_t AlphaEncodingManager::Decode(std::string input) {
         splay,
         joyX,
         joyY,
-        tokens[VRCommDataInputPosition::JOY_BTN] == 1,
-        tokens[VRCommDataInputPosition::BTN_TRG] == 1,
-        tokens[VRCommDataInputPosition::BTN_A] == 1,
-        tokens[VRCommDataInputPosition::BTN_B] == 1,
-        tokens[VRCommDataInputPosition::GES_GRAB] == 1,
-        tokens[VRCommDataInputPosition::GES_PINCH] == 1
+        argValid(input, 'H'), //joystick click
+        argValid(input, 'I'), //trigger
+        argValid(input, 'J'), //A button
+        argValid(input, 'K'), //B button
+        argValid(input, 'L'), //grab
+        argValid(input, 'M') //pinch
     );
 
     return commData;


### PR DESCRIPTION
Alpha encoding uses the wasted data in the delimiter from legacy to allow for optional arguments and redundancy over smaller packets.