### PR TITLE
Fix overlay vive trackers

### DIFF
--- a/overlay/main.cpp
+++ b/overlay/main.cpp
@@ -80,11 +80,14 @@ void DiscoverController(vr::ETrackedControllerRole role) {
 
       if (controllerType == vr::ETrackedDeviceClass::TrackedDeviceClass_GenericTracker ||
           controllerType == vr::ETrackedDeviceClass::TrackedDeviceClass_Controller) {
-        if (role == vr::ETrackedControllerRole::TrackedControllerRole_RightHand ||
+        /*if (role == vr::ETrackedControllerRole::TrackedControllerRole_RightHand ||
             reservedRightHand) {
           curFound = i;
         } else if (role == vr::ETrackedControllerRole::TrackedControllerRole_LeftHand) {
           reservedRightHand = true;
+        }*/
+        if (role == deviceRole) {
+            curFound = i;
         }
       }
       

--- a/overlay/main.cpp
+++ b/overlay/main.cpp
@@ -62,11 +62,6 @@ void DiscoverController(vr::ETrackedControllerRole role) {
 
       short deviceRole = vr::VRSystem()->GetControllerRoleForTrackedDeviceIndex(i);
 
-      /*if (deviceRole == role) {
-        curFound = i;
-        break;
-      };*/
-
       int32_t controllerHint = vr::VRSystem()->GetInt32TrackedDeviceProperty(
           i, vr::ETrackedDeviceProperty::Prop_ControllerRoleHint_Int32);
 
@@ -80,12 +75,6 @@ void DiscoverController(vr::ETrackedControllerRole role) {
 
       if (controllerType == vr::ETrackedDeviceClass::TrackedDeviceClass_GenericTracker ||
           controllerType == vr::ETrackedDeviceClass::TrackedDeviceClass_Controller) {
-        /*if (role == vr::ETrackedControllerRole::TrackedControllerRole_RightHand ||
-            reservedRightHand) {
-          curFound = i;
-        } else if (role == vr::ETrackedControllerRole::TrackedControllerRole_LeftHand) {
-          reservedRightHand = true;
-        }*/
         if (role == deviceRole) {
             curFound = i;
         }

--- a/overlay/main.cpp
+++ b/overlay/main.cpp
@@ -47,7 +47,9 @@ void GetAndSendControllerId(int id, vr::ETrackedControllerRole role) {
 void DiscoverController(vr::ETrackedControllerRole role) {
   int lastFound = -1;
   int curFound = -1;
+
   while (appActive) {
+    bool reservedRightHand = false;
     for (int32_t i = 1; i < vr::k_unMaxTrackedDeviceCount; i++) {
       char thisManufacturer[1024];
       uint32_t err = vr::VRSystem()->GetStringTrackedDeviceProperty(
@@ -64,7 +66,7 @@ void DiscoverController(vr::ETrackedControllerRole role) {
         curFound = i;
         break;
       };
-       
+
       int32_t controllerHint = vr::VRSystem()->GetInt32TrackedDeviceProperty(
           i, vr::ETrackedDeviceProperty::Prop_ControllerRoleHint_Int32);
 
@@ -72,6 +74,20 @@ void DiscoverController(vr::ETrackedControllerRole role) {
         curFound = i;
         break;
       }
+      
+      int controllerType = vr::VRSystem()->GetInt32TrackedDeviceProperty(
+          i, vr::ETrackedDeviceProperty::Prop_DeviceClass_Int32);
+
+      if (controllerType == vr::ETrackedDeviceClass::TrackedDeviceClass_GenericTracker ||
+          controllerType == vr::ETrackedDeviceClass::TrackedDeviceClass_Controller) {
+        if (role == vr::ETrackedControllerRole::TrackedControllerRole_RightHand ||
+            reservedRightHand) {
+          curFound = i;
+        } else if (role == vr::ETrackedControllerRole::TrackedControllerRole_LeftHand) {
+          reservedRightHand = true;
+        }
+      }
+      
     }
 
     if (curFound != lastFound) {

--- a/overlay/main.cpp
+++ b/overlay/main.cpp
@@ -62,10 +62,10 @@ void DiscoverController(vr::ETrackedControllerRole role) {
 
       short deviceRole = vr::VRSystem()->GetControllerRoleForTrackedDeviceIndex(i);
 
-      if (deviceRole == role) {
+      /*if (deviceRole == role) {
         curFound = i;
         break;
-      };
+      };*/
 
       int32_t controllerHint = vr::VRSystem()->GetInt32TrackedDeviceProperty(
           i, vr::ETrackedDeviceProperty::Prop_ControllerRoleHint_Int32);

--- a/overlay/main.cpp
+++ b/overlay/main.cpp
@@ -49,7 +49,6 @@ void DiscoverController(vr::ETrackedControllerRole role) {
   int curFound = -1;
 
   while (appActive) {
-    bool reservedRightHand = false;
     for (int32_t i = 1; i < vr::k_unMaxTrackedDeviceCount; i++) {
       char thisManufacturer[1024];
       uint32_t err = vr::VRSystem()->GetStringTrackedDeviceProperty(


### PR DESCRIPTION
Before, the overlay was not taking the handedness of Vive trackers. This PR should fix that.