### PR TITLE
Fix joystick for alpha encoding manager

### DIFF
--- a/src/Encode/AlphaEncodingManager.cpp
+++ b/src/Encode/AlphaEncodingManager.cpp
@@ -64,7 +64,7 @@ VRCommData_t AlphaEncodingManager::Decode(std::string input) {
     float joyY = 0;
 
     if (argValid(input, 'F'))
-      joyX = 2 * stof(getArgumentSubstring(input, 'E').substr(1, std::string::npos)) / m_maxAnalogValue - 1;
+      joyX = 2 * stof(getArgumentSubstring(input, 'F').substr(1, std::string::npos)) / m_maxAnalogValue - 1;
     if (argValid(input, 'G'))
       joyY = 2 * stof(getArgumentSubstring(input, 'G').substr(1, std::string::npos)) / m_maxAnalogValue - 1;
 


### PR DESCRIPTION
Joystick X-axis was using E instead of F, which meant the pinky was controlling the joystick.

This is a one-line fix to that.