### PR TITLE
Update discord link to static link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ OpenGloves is an OpenVR driver for DIY Virtual Reality Gloves. Using OpenVR's dr
 
 **Problems?**
 * Check [Troubleshooting](https://github.com/LucidVR/opengloves-driver/wiki/Troubleshooting)
-  * Didn't help? Contact us on the [Community Discord Server](https://discord.com/invite/Y6XTvnHDUC)
+  * Didn't help? Contact us on the [Community Discord Server](https://discord.com/invite/lucidvr)
 ## Building
 If you want to use the driver as-is, refer to [Installation and Usage](#Installation-and-Usage).  
 If you are planning on modifying source files, refer to [BUILDING.md](https://github.com/LucidVR/opengloves-driver/blob/develop/BUILDING.md).


### PR DESCRIPTION
Current link for discord in the readme is invalid, this will update it to a static link that should never need to change (as long as it stays over 30 boosts)