### PR TITLE
Fix missing library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ add_library("${OPENGLOVE_PROJECT}" SHARED "${HEADERS}" "${SOURCES}")
 target_include_directories("${OPENGLOVE_PROJECT}" PUBLIC "${OPENVR_INCLUDE_DIR}")
 
 target_include_directories("${OPENGLOVE_PROJECT}" PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include/")
-target_link_libraries("${OPENGLOVE_PROJECT}" PUBLIC "${OPENVR_LIB}" wsock32.lib ws2_32.lib Bthprops.lib)
+target_link_libraries("${OPENGLOVE_PROJECT}" PUBLIC "${OPENVR_LIB}" setupapi wsock32 ws2_32 bthprops)
 
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/include" PREFIX "Header Files" FILES ${HEADERS})
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/src" PREFIX "Source Files" FILES ${SOURCES})


### PR DESCRIPTION
Adds `setupapi` to list of link libraries to fix issues with SteamVR error code 126 for some users