### PR TITLE
Generalize BTSerial function signatures

### DIFF
--- a/include/Communication/BTSerialCommunicationManager.h
+++ b/include/Communication/BTSerialCommunicationManager.h
@@ -36,10 +36,10 @@ class BTSerialCommunicationManager : public ICommunicationManager {
  private:
   void ListenerThread(const std::function<void(VRCommData_t)>& callback);
   bool ReceiveNextPacket(std::string& buff);
-  bool getPairedEsp32BtAddress();
+  bool getPairedDeviceBtAddress();
   bool startupWindowsSocket();
-  bool connectToEsp32();
-  bool sendMessageToEsp32();
+  bool connectToDevice();
+  bool sendMessageToDevice();
   bool m_isConnected;
   std::atomic<bool> m_threadActive;
   std::thread m_serialThread;
@@ -48,7 +48,7 @@ class BTSerialCommunicationManager : public ICommunicationManager {
 
   VRBTSerialConfiguration_t m_btSerialConfiguration;
 
-  BTH_ADDR m_esp32BtAddress;
+  BTH_ADDR m_deviceBtAddress;
   SOCKADDR_BTH m_btSocketAddress;
   SOCKET m_btClientSocket;
   WCHAR* m_wcDeviceName;


### PR DESCRIPTION
Currently on `develop`, a lot of the function names for the BTSerial manager include the text "ESP32", along with the printouts. As OpenGloves seeks to be open to as much hardware as possible, it is in the project's best interest to generalize these.