### PR TITLE
Added configuration for baud rate

### DIFF
--- a/include/DeviceConfiguration.h
+++ b/include/DeviceConfiguration.h
@@ -25,8 +25,9 @@ enum VRDeviceDriver {
 
 struct VRSerialConfiguration_t {
     std::string port;
+    int baudRate;
 
-    VRSerialConfiguration_t(std::string port) : port(port) {};
+    VRSerialConfiguration_t(std::string port, int baudRate) : port(port), baudRate(baudRate) {};
 };
 
 struct VRBTSerialConfiguration_t {

--- a/openglove/resources/settings/default.vrsettings
+++ b/openglove/resources/settings/default.vrsettings
@@ -47,7 +47,8 @@
     "__type": "communication_protocol:0",
     "__title": "USB Serial",
     "left_port": "\\\\.\\COM4",
-    "right_port": "\\\\.\\COM5"
+    "right_port": "\\\\.\\COM5",
+    "baud_rate": 115200
   },
   "communication_btserial": 
   {

--- a/src/Communication/SerialCommunicationManager.cpp
+++ b/src/Communication/SerialCommunicationManager.cpp
@@ -27,7 +27,7 @@ void SerialCommunicationManager::Connect() {
       DebugDriverLog("Serial error: failed to get current serial parameters!");
     } else {
       // Define serial connection parameters for the arduino board
-      dcbSerialParams.BaudRate = CBR_115200;
+      dcbSerialParams.BaudRate = m_serialConfiguration.baudRate;
       dcbSerialParams.ByteSize = 8;
       dcbSerialParams.StopBits = ONESTOPBIT;
       dcbSerialParams.Parity = NOPARITY;

--- a/src/DeviceProvider.cpp
+++ b/src/DeviceProvider.cpp
@@ -129,7 +129,7 @@ std::unique_ptr<IDeviceDriver> DeviceProvider::InstantiateDeviceDriver(
       vr::VRSettings()->GetString("communication_serial", isRightHand ? "right_port" : "left_port",
                                   port, sizeof(port));
       const int baudRate = vr::VRSettings()->GetInt32("communication_serial", "baud_rate");
-      VRSerialConfiguration_t serialSettings(port);
+      VRSerialConfiguration_t serialSettings(port, baudRate);
 
       communicationManager =
           std::make_unique<SerialCommunicationManager>(serialSettings, std::move(encodingManager));

--- a/src/DeviceProvider.cpp
+++ b/src/DeviceProvider.cpp
@@ -128,6 +128,7 @@ std::unique_ptr<IDeviceDriver> DeviceProvider::InstantiateDeviceDriver(
       char port[16];
       vr::VRSettings()->GetString("communication_serial", isRightHand ? "right_port" : "left_port",
                                   port, sizeof(port));
+      const int baudRate = vr::VRSettings()->GetInt32("communication_serial", "baud_rate");
       VRSerialConfiguration_t serialSettings(port);
 
       communicationManager =


### PR DESCRIPTION
Added configuration for baud rate within the serial communication protocol. Defaulting to previous value of 115200.

This PR is to address my feature request #119 