### PR TITLE
Fix incorrectly documented finger orders in alpha encoding

### DIFF
--- a/src/Encode/AlphaEncodingManager.cpp
+++ b/src/Encode/AlphaEncodingManager.cpp
@@ -7,11 +7,11 @@
 
 /* Alpha encoding uses the wasted data in the delimiter from legacy to allow for optional arguments and redundancy over smaller packets
 *Alpha Encoding Manager Arguments:
-* A - Pinky Finger Position
-* B - Ring Finger Position
+* A - Thumb Finger Position
+* B - Index Finger Position
 * C - Middle Finger Position
-* D - Index Finger Position
-* E - Thumb Finger Position
+* D - Ring Finger Position
+* E - Pinky Finger Position
 * F - Joystick X
 * G - Joystick Y
 * H - Joystick click


### PR DESCRIPTION
The comments in Alpha Encoding had the indices for each finger backward. This quick PR just puts them in the correct order.