### PR TITLE
Removed all warnings from VS compilation, and updated AlphaEncodingManager to use enum

### DIFF
--- a/include/Calibration.h
+++ b/include/Calibration.h
@@ -19,5 +19,5 @@ public:
 
 private:
     vr::DriverPose_t m_maintainPose;
-    bool m_isCalibrating = false;
+    bool m_isCalibrating;
 };

--- a/include/DeviceConfiguration.h
+++ b/include/DeviceConfiguration.h
@@ -8,17 +8,17 @@
 static const char *c_driverSettingsSection = "driver_openglove";
 static const char *c_poseSettingsSection = "pose_settings";
 
-enum VRCommunicationProtocol {
+enum class VRCommunicationProtocol {
 	SERIAL = 0,
 	BTSERIAL = 1,
 };
 
-enum VREncodingProtocol {
+enum class VREncodingProtocol {
     LEGACY = 0,
     ALPHA = 1,
 };
 
-enum VRDeviceDriver {
+enum class VRDeviceDriver {
     LUCIDGLOVES = 0,
     EMULATED_KNUCKLES = 1,
 };

--- a/include/Encode/AlphaEncodingManager.h
+++ b/include/Encode/AlphaEncodingManager.h
@@ -2,6 +2,43 @@
 
 #include "Encode/EncodingManager.h"
 
+enum class VRCommDataAlphaEncodingCharacter : char {
+	FIN_PINKY = 'A',
+	FIN_RING = 'B',
+	FIN_MIDDLE = 'C',
+	FIN_INDEX = 'D',
+	FIN_THUMB = 'E',
+	JOY_X = 'F',
+	JOY_Y = 'G',
+	JOY_BTN = 'H',
+	BTN_TRG = 'I',
+	BTN_A = 'J',
+	BTN_B = 'K',
+	GES_GRAB = 'L',
+	GES_PINCH = 'M',
+	BTN_MENU = 'N',
+	BTN_CALIB = 'O',
+};
+
+const char VRCommDataAlphaEncodingCharacters[] = {
+	(char)VRCommDataAlphaEncodingCharacter::FIN_PINKY,
+	(char)VRCommDataAlphaEncodingCharacter::FIN_RING,
+	(char)VRCommDataAlphaEncodingCharacter::FIN_MIDDLE,
+	(char)VRCommDataAlphaEncodingCharacter::FIN_INDEX,
+	(char)VRCommDataAlphaEncodingCharacter::FIN_THUMB,
+	(char)VRCommDataAlphaEncodingCharacter::JOY_X,
+	(char)VRCommDataAlphaEncodingCharacter::JOY_Y,
+	(char)VRCommDataAlphaEncodingCharacter::JOY_BTN,
+	(char)VRCommDataAlphaEncodingCharacter::BTN_TRG,
+	(char)VRCommDataAlphaEncodingCharacter::BTN_A,
+	(char)VRCommDataAlphaEncodingCharacter::BTN_B,
+	(char)VRCommDataAlphaEncodingCharacter::GES_GRAB,
+	(char)VRCommDataAlphaEncodingCharacter::GES_PINCH,
+	(char)VRCommDataAlphaEncodingCharacter::BTN_MENU,
+	(char)VRCommDataAlphaEncodingCharacter::BTN_CALIB,
+	(char)0                                             // Turns into a null terminated string
+};
+
 class AlphaEncodingManager : public IEncodingManager {
 public:
 	AlphaEncodingManager(float maxAnalogValue) : m_maxAnalogValue(maxAnalogValue){};
@@ -12,7 +49,7 @@ public:
 
        private:
     std::string getArgumentSubstring(std::string str, char del);
+           bool argValid(std::string str, char del);
 
 	float m_maxAnalogValue;
-	const char* alphabet = "ABCDEFGHIJKLMNO";  // expand as more letters are added to manager
 };

--- a/include/Encode/AlphaEncodingManager.h
+++ b/include/Encode/AlphaEncodingManager.h
@@ -8,11 +8,7 @@ public:
 	
 	//decode the given string into a VRCommData_t
 	VRCommData_t Decode(std::string input);
-     std::string Encode(const VRFFBData_t& input);
-
-       private:
-    std::string getArgumentSubstring(std::string str, char del);
-           bool argValid(std::string str, char del);
+	 std::string Encode(const VRFFBData_t& input);
 
 	float m_maxAnalogValue;
 };

--- a/include/Encode/AlphaEncodingManager.h
+++ b/include/Encode/AlphaEncodingManager.h
@@ -2,50 +2,13 @@
 
 #include "Encode/EncodingManager.h"
 
-enum class VRCommDataAlphaEncodingCharacter : char {
-	FIN_THUMB = 'A',
-	FIN_INDEX = 'B',
-	FIN_MIDDLE = 'C',
-	FIN_RING = 'D',
-	FIN_PINKY = 'E',
-	JOY_X = 'F',
-	JOY_Y = 'G',
-	JOY_BTN = 'H',
-	BTN_TRG = 'I',
-	BTN_A = 'J',
-	BTN_B = 'K',
-	GES_GRAB = 'L',
-	GES_PINCH = 'M',
-	BTN_MENU = 'N',
-	BTN_CALIB = 'O',
-};
-
-const char VRCommDataAlphaEncodingCharacters[] = {
-	(char)VRCommDataAlphaEncodingCharacter::FIN_THUMB,
-	(char)VRCommDataAlphaEncodingCharacter::FIN_INDEX,
-	(char)VRCommDataAlphaEncodingCharacter::FIN_MIDDLE,
-	(char)VRCommDataAlphaEncodingCharacter::FIN_RING,
-	(char)VRCommDataAlphaEncodingCharacter::FIN_PINKY,
-	(char)VRCommDataAlphaEncodingCharacter::JOY_X,
-	(char)VRCommDataAlphaEncodingCharacter::JOY_Y,
-	(char)VRCommDataAlphaEncodingCharacter::JOY_BTN,
-	(char)VRCommDataAlphaEncodingCharacter::BTN_TRG,
-	(char)VRCommDataAlphaEncodingCharacter::BTN_A,
-	(char)VRCommDataAlphaEncodingCharacter::BTN_B,
-	(char)VRCommDataAlphaEncodingCharacter::GES_GRAB,
-	(char)VRCommDataAlphaEncodingCharacter::GES_PINCH,
-	(char)VRCommDataAlphaEncodingCharacter::BTN_MENU,
-	(char)VRCommDataAlphaEncodingCharacter::BTN_CALIB,
-	(char)0                                             // Turns into a null terminated string
-};
-
 class AlphaEncodingManager : public IEncodingManager {
 public:
 	AlphaEncodingManager(float maxAnalogValue) : m_maxAnalogValue(maxAnalogValue){};
 	
 	//decode the given string into a VRCommData_t
 	VRCommData_t Decode(std::string input);
-    std::string Encode(const VRFFBData_t& input);
+     std::string Encode(const VRFFBData_t& input);
 
        private:
     std::string getArgumentSubstring(std::string str, char del);

--- a/include/Encode/AlphaEncodingManager.h
+++ b/include/Encode/AlphaEncodingManager.h
@@ -3,11 +3,11 @@
 #include "Encode/EncodingManager.h"
 
 enum class VRCommDataAlphaEncodingCharacter : char {
-	FIN_PINKY = 'A',
-	FIN_RING = 'B',
+	FIN_THUMB = 'A',
+	FIN_INDEX = 'B',
 	FIN_MIDDLE = 'C',
-	FIN_INDEX = 'D',
-	FIN_THUMB = 'E',
+	FIN_RING = 'D',
+	FIN_PINKY = 'E',
 	JOY_X = 'F',
 	JOY_Y = 'G',
 	JOY_BTN = 'H',
@@ -21,11 +21,11 @@ enum class VRCommDataAlphaEncodingCharacter : char {
 };
 
 const char VRCommDataAlphaEncodingCharacters[] = {
-	(char)VRCommDataAlphaEncodingCharacter::FIN_PINKY,
-	(char)VRCommDataAlphaEncodingCharacter::FIN_RING,
-	(char)VRCommDataAlphaEncodingCharacter::FIN_MIDDLE,
-	(char)VRCommDataAlphaEncodingCharacter::FIN_INDEX,
 	(char)VRCommDataAlphaEncodingCharacter::FIN_THUMB,
+	(char)VRCommDataAlphaEncodingCharacter::FIN_INDEX,
+	(char)VRCommDataAlphaEncodingCharacter::FIN_MIDDLE,
+	(char)VRCommDataAlphaEncodingCharacter::FIN_RING,
+	(char)VRCommDataAlphaEncodingCharacter::FIN_PINKY,
 	(char)VRCommDataAlphaEncodingCharacter::JOY_X,
 	(char)VRCommDataAlphaEncodingCharacter::JOY_Y,
 	(char)VRCommDataAlphaEncodingCharacter::JOY_BTN,

--- a/include/Encode/EncodingManager.h
+++ b/include/Encode/EncodingManager.h
@@ -42,3 +42,16 @@ class IEncodingManager {
  private:
   float m_maxAnalogValue = 0.0;
 };
+
+template <typename... Args>
+std::string string_format(const std::string& format, Args... args) {
+  int size_s = std::snprintf(nullptr, 0, format.c_str(), args...) + 1;  // Extra space for '\0'
+  if (size_s <= 0) {
+    DriverLog("Error decoding string");
+    return "";
+  }
+  auto size = static_cast<size_t>(size_s);
+  auto buf = std::make_unique<char[]>(size);
+  std::snprintf(buf.get(), size, format.c_str(), args...);
+  return std::string(buf.get(), buf.get() + size - 1);  // We don't want the '\0' inside
+}

--- a/include/Encode/EncodingManager.h
+++ b/include/Encode/EncodingManager.h
@@ -33,23 +33,6 @@ struct VRCommData_t {
     bool calibrate;
 };
 
-enum VRCommDataInputPosition {
-  FIN_PINKY,
-  FIN_RING,
-  FIN_MIDDLE,
-  FIN_INDEX,
-  FIN_THUMB,
-  JOY_X,
-  JOY_Y,
-  JOY_BTN,
-  BTN_TRG,
-  BTN_A,
-  BTN_B,
-  GES_GRAB,
-  GES_PINCH,
-  MAX,
-};
-
 class IEncodingManager {
  public:
   virtual VRCommData_t Decode(std::string input) = 0;
@@ -57,5 +40,5 @@ class IEncodingManager {
   virtual ~IEncodingManager(){};
 
  private:
-  float m_maxAnalogValue;
+  float m_maxAnalogValue = 0.0;
 };

--- a/include/Encode/LegacyEncodingManager.h
+++ b/include/Encode/LegacyEncodingManager.h
@@ -3,6 +3,23 @@
 #include <Encode/EncodingManager.h>
 #include "ForceFeedback.h"
 
+enum class VRCommDataLegacyEncodingPosition : int {
+  FIN_PINKY,
+  FIN_RING,
+  FIN_MIDDLE,
+  FIN_INDEX,
+  FIN_THUMB,
+  JOY_X,
+  JOY_Y,
+  JOY_BTN,
+  BTN_TRG,
+  BTN_A,
+  BTN_B,
+  GES_GRAB,
+  GES_PINCH,
+  MAX,
+};
+
 class LegacyEncodingManager : public IEncodingManager {
  public:
   LegacyEncodingManager(float maxAnalogValue) : m_maxAnalogValue(maxAnalogValue){};

--- a/include/Encode/LegacyEncodingManager.h
+++ b/include/Encode/LegacyEncodingManager.h
@@ -3,23 +3,6 @@
 #include <Encode/EncodingManager.h>
 #include "ForceFeedback.h"
 
-enum class VRCommDataLegacyEncodingPosition : int {
-  FIN_THUMB,
-  FIN_INDEX,
-  FIN_MIDDLE,
-  FIN_RING,
-  FIN_PINKY,
-  JOY_X,
-  JOY_Y,
-  JOY_BTN,
-  BTN_TRG,
-  BTN_A,
-  BTN_B,
-  GES_GRAB,
-  GES_PINCH,
-  MAX,
-};
-
 class LegacyEncodingManager : public IEncodingManager {
  public:
   LegacyEncodingManager(float maxAnalogValue) : m_maxAnalogValue(maxAnalogValue){};

--- a/include/Encode/LegacyEncodingManager.h
+++ b/include/Encode/LegacyEncodingManager.h
@@ -4,11 +4,11 @@
 #include "ForceFeedback.h"
 
 enum class VRCommDataLegacyEncodingPosition : int {
-  FIN_PINKY,
-  FIN_RING,
-  FIN_MIDDLE,
-  FIN_INDEX,
   FIN_THUMB,
+  FIN_INDEX,
+  FIN_MIDDLE,
+  FIN_RING,
+  FIN_PINKY,
   JOY_X,
   JOY_Y,
   JOY_BTN,

--- a/include/Quaternion.h
+++ b/include/Quaternion.h
@@ -2,7 +2,7 @@
 
 #include "openvr_driver.h"
 
-double DegToRad(int degrees);
+double DegToRad(double degrees);
 double RadToDeg(double rad);
 
 

--- a/overlay/main.cpp
+++ b/overlay/main.cpp
@@ -38,7 +38,7 @@ void GetAndSendControllerId(int id, vr::ETrackedControllerRole role) {
     pipeName = "\\\\.\\pipe\\vrapplication\\discovery\\right";
   }
 
-  ControllerPipeData data;
+  ControllerPipeData data{};
   data.controllerId = id;
 
   pipeHelper->ConnectAndSendPipe(pipeName, data);
@@ -123,7 +123,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdL
   return 0;
 }
 
-PipeHelper::PipeHelper() {}
+PipeHelper::PipeHelper() : m_pipeHandle(NULL) {}
 
 bool PipeHelper::ConnectAndSendPipe(const std::string& pipeName, ControllerPipeData data) {
   while (1) {
@@ -139,11 +139,11 @@ bool PipeHelper::ConnectAndSendPipe(const std::string& pipeName, ControllerPipeD
     if (m_pipeHandle != INVALID_HANDLE_VALUE) break;
 
     if (GetLastError() != ERROR_PIPE_BUSY) {
-      return -1;
+      return false;
     }
 
     if (!WaitNamedPipe(pipeName.c_str(), 1000)) {
-      return -1;
+      return false;
     }
   }
 

--- a/overlay/main.h
+++ b/overlay/main.h
@@ -11,7 +11,6 @@ class PipeHelper {
   PipeHelper();
 
   bool ConnectAndSendPipe(const std::string& pipeName, ControllerPipeData data);
-  void Send();
 
  private:
   HANDLE m_pipeHandle;

--- a/src/Calibration.cpp
+++ b/src/Calibration.cpp
@@ -6,9 +6,7 @@
 #include "DriverLog.h"
 #include "Quaternion.h"
 
-Calibration::Calibration() {
-    m_isCalibrating = false;
-}
+Calibration::Calibration() : m_maintainPose(), m_isCalibrating(false) {}
 
 void Calibration::StartCalibration(vr::DriverPose_t maintainPose) {
     maintainPose.vecVelocity[0] = 0;
@@ -39,9 +37,9 @@ VRPoseConfiguration_t Calibration::FinishCalibration(vr::TrackedDevicePose_t con
     poseConfiguration.angleOffsetQuaternion.y = transformQuat.y;
     poseConfiguration.angleOffsetQuaternion.z = transformQuat.z;
 
-    vr::HmdVector3_t differenceVector = { m_maintainPose.vecPosition[0] - controllerMatrix.m[0][3],
-                                          m_maintainPose.vecPosition[1] - controllerMatrix.m[1][3],
-                                          m_maintainPose.vecPosition[2] - controllerMatrix.m[2][3] };
+    vr::HmdVector3_t differenceVector = { (float)(m_maintainPose.vecPosition[0] - controllerMatrix.m[0][3]),
+                                          (float)(m_maintainPose.vecPosition[1] - controllerMatrix.m[1][3]),
+                                          (float)(m_maintainPose.vecPosition[2] - controllerMatrix.m[2][3]) };
 
     vr::HmdQuaternion_t transformInverse = QuatConjugate(controllerQuat);
     vr::HmdMatrix33_t transformMatrix = QuaternionToMatrix(transformInverse);

--- a/src/Communication/SerialCommunicationManager.cpp
+++ b/src/Communication/SerialCommunicationManager.cpp
@@ -69,7 +69,7 @@ void SerialCommunicationManager::ListenerThread(const std::function<void(VRCommD
         callback(commData);
         
         Write();
-      } catch (const std::invalid_argument& ia) {
+      } catch (const std::invalid_argument&) {
         DriverLog("Received error from encoding manager. Skipping...");
       }
     } else {
@@ -82,7 +82,7 @@ void SerialCommunicationManager::ListenerThread(const std::function<void(VRCommD
 }
 
 bool SerialCommunicationManager::ReceiveNextPacket(std::string& buff) {
-  DWORD dwCommEvent;
+  DWORD dwCommEvent = 0;
   DWORD dwRead = 0;
 
   if (!SetCommMask(m_hSerial, EV_RXCHAR)) {
@@ -90,13 +90,11 @@ bool SerialCommunicationManager::ReceiveNextPacket(std::string& buff) {
     return false;
   }
 
-  char nextChar;
-  int bytesRead = 0;
+  char nextChar = 0;
   if (WaitCommEvent(m_hSerial, &dwCommEvent, NULL)) {
     do {
       if (ReadFile(m_hSerial, &nextChar, 1, &dwRead, NULL)) {
         buff += nextChar;
-        bytesRead++;
       } else {
         DebugDriverLog("Read file error");
         return false;
@@ -123,7 +121,7 @@ bool SerialCommunicationManager::Write() {
 
   DWORD bytesSend;
 
-  if (!WriteFile(this->m_hSerial, (void*)buf, strlen(buf), &bytesSend, 0)) {
+  if (!WriteFile(this->m_hSerial, (void*)buf, (DWORD)strlen(buf), &bytesSend, 0)) {
     ClearCommError(this->m_hSerial, &this->m_errors, &this->m_status);
 
     DebugDriverLog("Error connecting writing to Serial Port.");

--- a/src/DeviceDriver/KnuckleDriver.cpp
+++ b/src/DeviceDriver/KnuckleDriver.cpp
@@ -238,7 +238,7 @@ void KnuckleDeviceDriver::StartDevice() {
         } else {
           if (m_controllerPose->isCalibrating()) m_controllerPose->FinishCalibration();
         }
-      } catch (const std::exception& e) {
+      } catch (const std::exception&) {
         DebugDriverLog("Exception caught while parsing comm data");
       }
     });

--- a/src/DeviceDriver/LucidGloveDriver.cpp
+++ b/src/DeviceDriver/LucidGloveDriver.cpp
@@ -148,7 +148,7 @@ void LucidGloveDeviceDriver::StartDevice() {
         } else {
           if (m_controllerPose->isCalibrating()) m_controllerPose->FinishCalibration();
         }
-      } catch (const std::exception& e) {
+      } catch (const std::exception&) {
         DebugDriverLog("Exception caught while parsing comm data");
       }
     });

--- a/src/DeviceProvider.cpp
+++ b/src/DeviceProvider.cpp
@@ -98,14 +98,15 @@ std::unique_ptr<IDeviceDriver> DeviceProvider::InstantiateDeviceDriver(
   switch (configuration.encodingProtocol) {
     default:
       DriverLog("No encoding protocol set. Using legacy.");
+      // fall through
     case VREncodingProtocol::LEGACY: {
-      const int maxAnalogValue = vr::VRSettings()->GetInt32("encoding_legacy", "max_analog_value");
+      const float maxAnalogValue = vr::VRSettings()->GetFloat("encoding_legacy", "max_analog_value");
       encodingManager = std::make_unique<LegacyEncodingManager>(maxAnalogValue);
       break;
     }
     case VREncodingProtocol::ALPHA: {
-      const int maxAnalogValue =
-          vr::VRSettings()->GetInt32("encoding_alpha", "max_analog_value");  //
+      const float maxAnalogValue =
+          vr::VRSettings()->GetFloat("encoding_alpha", "max_analog_value");  //
       encodingManager = std::make_unique<AlphaEncodingManager>(maxAnalogValue);
       break;
     }
@@ -124,6 +125,7 @@ std::unique_ptr<IDeviceDriver> DeviceProvider::InstantiateDeviceDriver(
     }
     default:
       DriverLog("No communication protocol set. Using serial.");
+      // fall through
     case VRCommunicationProtocol::SERIAL:
       char port[16];
       vr::VRSettings()->GetString("communication_serial", isRightHand ? "right_port" : "left_port",
@@ -149,6 +151,7 @@ std::unique_ptr<IDeviceDriver> DeviceProvider::InstantiateDeviceDriver(
 
     default:
       DriverLog("No device driver selected. Using lucidgloves.");
+      // fall through
     case VRDeviceDriver::LUCIDGLOVES: {
       char serialNumber[32];
       vr::VRSettings()->GetString("device_lucidgloves",

--- a/src/Encode/AlphaEncodingManager.cpp
+++ b/src/Encode/AlphaEncodingManager.cpp
@@ -43,7 +43,7 @@ const char VRCommDataAlphaEncodingCharacters[] = {
 	(char)0                                             // Turns into a null terminated string
 };
 
-std::string AlphaEncodingManager::getArgumentSubstring(std::string str, char del) { 
+std::string getArgumentSubstring(std::string str, char del) { 
     size_t start = str.find(del);
     if (start == std::string::npos)
         return std::string();
@@ -51,7 +51,7 @@ std::string AlphaEncodingManager::getArgumentSubstring(std::string str, char del
     return str.substr(start + 1, end - (start + 1));
 }
 
-bool AlphaEncodingManager::argValid(std::string str, char del) { return str.find(del) != std::string::npos; }
+bool argValid(std::string str, char del) { return str.find(del) != std::string::npos; }
 
 VRCommData_t AlphaEncodingManager::Decode(std::string input) {
 

--- a/src/Encode/AlphaEncodingManager.cpp
+++ b/src/Encode/AlphaEncodingManager.cpp
@@ -27,21 +27,21 @@ VRCommData_t AlphaEncodingManager::Decode(std::string input) {
         splay[i] = 0.5;
     }
 
-    if (argValid(input, (char)VRCommDataAlphaEncodingCharacter::FIN_PINKY))
+    if (argValid(input, (char)VRCommDataAlphaEncodingCharacter::FIN_THUMB))
       flexion[0] =
-          stof(getArgumentSubstring(input, (char)VRCommDataAlphaEncodingCharacter::FIN_PINKY)) / m_maxAnalogValue;
-    if (argValid(input, (char)VRCommDataAlphaEncodingCharacter::FIN_RING))
+          stof(getArgumentSubstring(input, (char)VRCommDataAlphaEncodingCharacter::FIN_THUMB)) / m_maxAnalogValue;
+    if (argValid(input, (char)VRCommDataAlphaEncodingCharacter::FIN_INDEX))
       flexion[1] =
-          stof(getArgumentSubstring(input, (char)VRCommDataAlphaEncodingCharacter::FIN_RING)) / m_maxAnalogValue;
+          stof(getArgumentSubstring(input, (char)VRCommDataAlphaEncodingCharacter::FIN_INDEX)) / m_maxAnalogValue;
     if (argValid(input, (char)VRCommDataAlphaEncodingCharacter::FIN_MIDDLE))
       flexion[2] =
           stof(getArgumentSubstring(input, (char)VRCommDataAlphaEncodingCharacter::FIN_MIDDLE)) / m_maxAnalogValue;
-    if (argValid(input, (char)VRCommDataAlphaEncodingCharacter::FIN_INDEX))
+    if (argValid(input, (char)VRCommDataAlphaEncodingCharacter::FIN_RING))
       flexion[3] =
-          stof(getArgumentSubstring(input, (char)VRCommDataAlphaEncodingCharacter::FIN_INDEX)) / m_maxAnalogValue;
-    if (argValid(input, (char)VRCommDataAlphaEncodingCharacter::FIN_THUMB))
+          stof(getArgumentSubstring(input, (char)VRCommDataAlphaEncodingCharacter::FIN_RING)) / m_maxAnalogValue;
+    if (argValid(input, (char)VRCommDataAlphaEncodingCharacter::FIN_PINKY))
       flexion[4] =
-          stof(getArgumentSubstring(input, (char)VRCommDataAlphaEncodingCharacter::FIN_THUMB)) / m_maxAnalogValue;
+          stof(getArgumentSubstring(input, (char)VRCommDataAlphaEncodingCharacter::FIN_PINKY)) / m_maxAnalogValue;
 
     float joyX = 0;
     float joyY = 0;

--- a/src/Encode/AlphaEncodingManager.cpp
+++ b/src/Encode/AlphaEncodingManager.cpp
@@ -83,6 +83,12 @@ std::string string_format(const std::string& format, Args... args) {
 }
 
 std::string AlphaEncodingManager::Encode(const VRFFBData_t& data) {
-  std::string result = string_format("A%dB%dC%dD%dE%d\n", data.thumbCurl, data.indexCurl, data.middleCurl, data.ringCurl, data.pinkyCurl);
+  std::string result = string_format("%c%d%c%d%c%d%c%d%c%d\n",
+     (char)VRCommDataAlphaEncodingCharacter::FIN_THUMB, data.thumbCurl,
+     (char)VRCommDataAlphaEncodingCharacter::FIN_INDEX, data.indexCurl,
+     (char)VRCommDataAlphaEncodingCharacter::FIN_MIDDLE, data.middleCurl,
+     (char)VRCommDataAlphaEncodingCharacter::FIN_RING, data.ringCurl,
+     (char)VRCommDataAlphaEncodingCharacter::FIN_PINKY, data.pinkyCurl
+  );
   return result;
 };

--- a/src/Encode/AlphaEncodingManager.cpp
+++ b/src/Encode/AlphaEncodingManager.cpp
@@ -6,6 +6,42 @@
 
 
 /* Alpha encoding uses the wasted data in the delimiter from legacy to allow for optional arguments and redundancy over smaller packets */
+enum class VRCommDataAlphaEncodingCharacter : char {
+	FIN_THUMB = 'A',
+	FIN_INDEX = 'B',
+	FIN_MIDDLE = 'C',
+	FIN_RING = 'D',
+	FIN_PINKY = 'E',
+	JOY_X = 'F',
+	JOY_Y = 'G',
+	JOY_BTN = 'H',
+	BTN_TRG = 'I',
+	BTN_A = 'J',
+	BTN_B = 'K',
+	GES_GRAB = 'L',
+	GES_PINCH = 'M',
+	BTN_MENU = 'N',
+	BTN_CALIB = 'O',
+};
+
+const char VRCommDataAlphaEncodingCharacters[] = {
+	(char)VRCommDataAlphaEncodingCharacter::FIN_THUMB,
+	(char)VRCommDataAlphaEncodingCharacter::FIN_INDEX,
+	(char)VRCommDataAlphaEncodingCharacter::FIN_MIDDLE,
+	(char)VRCommDataAlphaEncodingCharacter::FIN_RING,
+	(char)VRCommDataAlphaEncodingCharacter::FIN_PINKY,
+	(char)VRCommDataAlphaEncodingCharacter::JOY_X,
+	(char)VRCommDataAlphaEncodingCharacter::JOY_Y,
+	(char)VRCommDataAlphaEncodingCharacter::JOY_BTN,
+	(char)VRCommDataAlphaEncodingCharacter::BTN_TRG,
+	(char)VRCommDataAlphaEncodingCharacter::BTN_A,
+	(char)VRCommDataAlphaEncodingCharacter::BTN_B,
+	(char)VRCommDataAlphaEncodingCharacter::GES_GRAB,
+	(char)VRCommDataAlphaEncodingCharacter::GES_PINCH,
+	(char)VRCommDataAlphaEncodingCharacter::BTN_MENU,
+	(char)VRCommDataAlphaEncodingCharacter::BTN_CALIB,
+	(char)0                                             // Turns into a null terminated string
+};
 
 std::string AlphaEncodingManager::getArgumentSubstring(std::string str, char del) { 
     size_t start = str.find(del);

--- a/src/Encode/AlphaEncodingManager.cpp
+++ b/src/Encode/AlphaEncodingManager.cpp
@@ -43,7 +43,7 @@ const char VRCommDataAlphaEncodingCharacters[] = {
 	(char)0                                             // Turns into a null terminated string
 };
 
-std::string getArgumentSubstring(std::string str, char del) { 
+static std::string getArgumentSubstring(std::string str, char del) { 
     size_t start = str.find(del);
     if (start == std::string::npos)
         return std::string();
@@ -51,7 +51,7 @@ std::string getArgumentSubstring(std::string str, char del) {
     return str.substr(start + 1, end - (start + 1));
 }
 
-bool argValid(std::string str, char del) { return str.find(del) != std::string::npos; }
+static bool argValid(std::string str, char del) { return str.find(del) != std::string::npos; }
 
 VRCommData_t AlphaEncodingManager::Decode(std::string input) {
 
@@ -103,19 +103,6 @@ VRCommData_t AlphaEncodingManager::Decode(std::string input) {
     );
 
     return commData;
-}
-
-template <typename... Args>
-std::string string_format(const std::string& format, Args... args) {
-  int size_s = std::snprintf(nullptr, 0, format.c_str(), args...) + 1;  // Extra space for '\0'
-  if (size_s <= 0) {
-    DriverLog("Error decoding string");
-    return "";
-  }
-  auto size = static_cast<size_t>(size_s);
-  auto buf = std::make_unique<char[]>(size);
-  std::snprintf(buf.get(), size, format.c_str(), args...);
-  return std::string(buf.get(), buf.get() + size - 1);  // We don't want the '\0' inside
 }
 
 std::string AlphaEncodingManager::Encode(const VRFFBData_t& data) {

--- a/src/Encode/AlphaEncodingManager.cpp
+++ b/src/Encode/AlphaEncodingManager.cpp
@@ -5,34 +5,17 @@
 #include "DriverLog.h"
 
 
-/* Alpha encoding uses the wasted data in the delimiter from legacy to allow for optional arguments and redundancy over smaller packets
-*Alpha Encoding Manager Arguments:
-* A - Pinky Finger Position
-* B - Ring Finger Position
-* C - Middle Finger Position
-* D - Index Finger Position
-* E - Thumb Finger Position
-* F - Joystick X
-* G - Joystick Y
-* H - Joystick click
-* I - Trigger button
-* J - A button
-* K - B button
-* L - Grab button
-* M - Pinch button
-* N - Menu button
-* O - Calibration Reset button
-*/
+/* Alpha encoding uses the wasted data in the delimiter from legacy to allow for optional arguments and redundancy over smaller packets */
 
 std::string AlphaEncodingManager::getArgumentSubstring(std::string str, char del) { 
-    int start = str.find(del);
+    size_t start = str.find(del);
     if (start == std::string::npos)
-        return NULL;
-    int end = str.find_first_of(alphabet, start + 1); //characters may not necessarily be in order, so end at any letter
+        return std::string();
+    size_t end = str.find_first_of(VRCommDataAlphaEncodingCharacters, start + 1);  // characters may not necessarily be in order, so end at any letter
     return str.substr(start + 1, end - (start + 1));
 }
 
-bool argValid(std::string str, char del) { return str.find(del) != std::string::npos; }
+bool AlphaEncodingManager::argValid(std::string str, char del) { return str.find(del) != std::string::npos; }
 
 VRCommData_t AlphaEncodingManager::Decode(std::string input) {
 
@@ -44,43 +27,43 @@ VRCommData_t AlphaEncodingManager::Decode(std::string input) {
         splay[i] = 0.5;
     }
 
-    if (argValid(input, 'A'))
+    if (argValid(input, (char)VRCommDataAlphaEncodingCharacter::FIN_PINKY))
       flexion[0] =
-          stof(getArgumentSubstring(input, 'A')) / m_maxAnalogValue;
-    if (argValid(input, 'B'))
+          stof(getArgumentSubstring(input, (char)VRCommDataAlphaEncodingCharacter::FIN_PINKY)) / m_maxAnalogValue;
+    if (argValid(input, (char)VRCommDataAlphaEncodingCharacter::FIN_RING))
       flexion[1] =
-          stof(getArgumentSubstring(input, 'B')) / m_maxAnalogValue;
-    if (argValid(input, 'C'))
+          stof(getArgumentSubstring(input, (char)VRCommDataAlphaEncodingCharacter::FIN_RING)) / m_maxAnalogValue;
+    if (argValid(input, (char)VRCommDataAlphaEncodingCharacter::FIN_MIDDLE))
       flexion[2] =
-          stof(getArgumentSubstring(input, 'C')) / m_maxAnalogValue;
-    if (argValid(input, 'D'))
+          stof(getArgumentSubstring(input, (char)VRCommDataAlphaEncodingCharacter::FIN_MIDDLE)) / m_maxAnalogValue;
+    if (argValid(input, (char)VRCommDataAlphaEncodingCharacter::FIN_INDEX))
       flexion[3] =
-          stof(getArgumentSubstring(input, 'D')) / m_maxAnalogValue;
-    if (argValid(input, 'E'))
+          stof(getArgumentSubstring(input, (char)VRCommDataAlphaEncodingCharacter::FIN_INDEX)) / m_maxAnalogValue;
+    if (argValid(input, (char)VRCommDataAlphaEncodingCharacter::FIN_THUMB))
       flexion[4] =
-          stof(getArgumentSubstring(input, 'E')) / m_maxAnalogValue;
+          stof(getArgumentSubstring(input, (char)VRCommDataAlphaEncodingCharacter::FIN_THUMB)) / m_maxAnalogValue;
 
     float joyX = 0;
     float joyY = 0;
 
-    if (argValid(input, 'F'))
-      joyX = 2 * stof(getArgumentSubstring(input, 'F')) / m_maxAnalogValue - 1;
-    if (argValid(input, 'G'))
-      joyY = 2 * stof(getArgumentSubstring(input, 'G')) / m_maxAnalogValue - 1;
+    if (argValid(input, (char)VRCommDataAlphaEncodingCharacter::JOY_X))
+      joyX = 2 * stof(getArgumentSubstring(input, (char)VRCommDataAlphaEncodingCharacter::JOY_X)) / m_maxAnalogValue - 1;
+    if (argValid(input, (char)VRCommDataAlphaEncodingCharacter::JOY_Y))
+      joyY = 2 * stof(getArgumentSubstring(input, (char)VRCommDataAlphaEncodingCharacter::JOY_Y)) / m_maxAnalogValue - 1;
 
     VRCommData_t commData(
         flexion,
         splay,
         joyX,
         joyY,
-        argValid(input, 'H'), //joystick click
-        argValid(input, 'I'), //trigger
-        argValid(input, 'J'), //A button
-        argValid(input, 'K'), //B button
-        argValid(input, 'L'), //grab
-        argValid(input, 'M'), //pinch
-        argValid(input, 'N'), //menu
-        argValid(input, 'O')  //calibration
+        argValid(input, (char)VRCommDataAlphaEncodingCharacter::JOY_BTN),
+        argValid(input, (char)VRCommDataAlphaEncodingCharacter::BTN_TRG),
+        argValid(input, (char)VRCommDataAlphaEncodingCharacter::BTN_A),
+        argValid(input, (char)VRCommDataAlphaEncodingCharacter::BTN_B),
+        argValid(input, (char)VRCommDataAlphaEncodingCharacter::GES_GRAB),
+        argValid(input, (char)VRCommDataAlphaEncodingCharacter::GES_PINCH),
+        argValid(input, (char)VRCommDataAlphaEncodingCharacter::BTN_MENU),
+        argValid(input, (char)VRCommDataAlphaEncodingCharacter::BTN_CALIB)
     );
 
     return commData;

--- a/src/Encode/LegacyEncodingManager.cpp
+++ b/src/Encode/LegacyEncodingManager.cpp
@@ -5,6 +5,23 @@
 
 #include "DriverLog.h"
 
+enum class VRCommDataLegacyEncodingPosition : int {
+  FIN_THUMB,
+  FIN_INDEX,
+  FIN_MIDDLE,
+  FIN_RING,
+  FIN_PINKY,
+  JOY_X,
+  JOY_Y,
+  JOY_BTN,
+  BTN_TRG,
+  BTN_A,
+  BTN_B,
+  GES_GRAB,
+  GES_PINCH,
+  MAX,
+};
+
 VRCommData_t LegacyEncodingManager::Decode(std::string input) {
   std::string buf;
   std::stringstream ss(input);

--- a/src/Encode/LegacyEncodingManager.cpp
+++ b/src/Encode/LegacyEncodingManager.cpp
@@ -9,8 +9,8 @@ VRCommData_t LegacyEncodingManager::Decode(std::string input) {
   std::string buf;
   std::stringstream ss(input);
 
-  std::vector<float> tokens(VRCommDataInputPosition::MAX);
-  std::fill(tokens.begin(), tokens.begin() + VRCommDataInputPosition::MAX, 0.0f);
+  std::vector<float> tokens((int)VRCommDataLegacyEncodingPosition::MAX);
+  std::fill(tokens.begin(), tokens.begin() + (int)VRCommDataLegacyEncodingPosition::MAX, 0.0f);
 
   short i = 0;
   while (getline(ss, buf, '&')) {
@@ -26,20 +26,20 @@ VRCommData_t LegacyEncodingManager::Decode(std::string input) {
     splay[i] = 0.5;
   }
 
-  const float joyX = (2 * tokens[VRCommDataInputPosition::JOY_X] / m_maxAnalogValue) - 1;
-  const float joyY = (2 * tokens[VRCommDataInputPosition::JOY_Y] / m_maxAnalogValue) - 1;
+  const float joyX = (2 * tokens[(int)VRCommDataLegacyEncodingPosition::JOY_X] / m_maxAnalogValue) - 1;
+  const float joyY = (2 * tokens[(int)VRCommDataLegacyEncodingPosition::JOY_Y] / m_maxAnalogValue) - 1;
 
     VRCommData_t commData(
         flexion,
         splay,
         joyX,
         joyY,
-        tokens[VRCommDataInputPosition::JOY_BTN] == 1,
-        tokens[VRCommDataInputPosition::BTN_TRG] == 1,
-        tokens[VRCommDataInputPosition::BTN_A] == 1,
-        tokens[VRCommDataInputPosition::BTN_B] == 1,
-        tokens[VRCommDataInputPosition::GES_GRAB] == 1,
-        tokens[VRCommDataInputPosition::GES_PINCH] == 1,
+        tokens[(int)VRCommDataLegacyEncodingPosition::JOY_BTN] == 1,
+        tokens[(int)VRCommDataLegacyEncodingPosition::BTN_TRG] == 1,
+        tokens[(int)VRCommDataLegacyEncodingPosition::BTN_A] == 1,
+        tokens[(int)VRCommDataLegacyEncodingPosition::BTN_B] == 1,
+        tokens[(int)VRCommDataLegacyEncodingPosition::GES_GRAB] == 1,
+        tokens[(int)VRCommDataLegacyEncodingPosition::GES_PINCH] == 1,
         false,
         false
     );

--- a/src/Encode/LegacyEncodingManager.cpp
+++ b/src/Encode/LegacyEncodingManager.cpp
@@ -64,19 +64,6 @@ VRCommData_t LegacyEncodingManager::Decode(std::string input) {
   return commData;
 }
 
-template <typename... Args>
-std::string string_format(const std::string& format, Args... args) {
-  int size_s = std::snprintf(nullptr, 0, format.c_str(), args...) + 1;  // Extra space for '\0'
-  if (size_s <= 0) {
-    DriverLog("Error decoding string");
-    return "";
-  }
-  auto size = static_cast<size_t>(size_s);
-  auto buf = std::make_unique<char[]>(size);
-  std::snprintf(buf.get(), size, format.c_str(), args...);
-  return std::string(buf.get(), buf.get() + size - 1);  // We don't want the '\0' inside
-}
-
 std::string LegacyEncodingManager::Encode(const VRFFBData_t& data) {
   std::string result = string_format("%d&%d&%d&%d&%d\n", data.thumbCurl, data.indexCurl, data.middleCurl, data.ringCurl, data.pinkyCurl);
   return result;

--- a/src/Quaternion.cpp
+++ b/src/Quaternion.cpp
@@ -1,15 +1,15 @@
 #include "Quaternion.h"
 #include <cmath>
 
-double DegToRad(int degrees) {
-	return degrees * M_PI / 180;
+double DegToRad(double degrees) {
+	return degrees * M_PI / 180.0;
 }
 double RadToDeg(double rad) {
-	return rad * 180 / M_PI;
+	return rad * 180.0 / M_PI;
 }
 
 vr::HmdVector3_t GetPosition(const vr::HmdMatrix34_t& matrix) {
-	vr::HmdVector3_t vector;
+	vr::HmdVector3_t vector{};
 
 	vector.v[0] = matrix.m[0][3];
 	vector.v[1] = matrix.m[1][3];
@@ -19,7 +19,7 @@ vr::HmdVector3_t GetPosition(const vr::HmdMatrix34_t& matrix) {
 }
 
 vr::HmdVector3_t CombinePosition(const vr::HmdMatrix34_t& matrix, const vr::HmdVector3_t& vec) {
-	vr::HmdVector3_t vector;
+	vr::HmdVector3_t vector{};
 
 	vector.v[0] = matrix.m[0][3] + vec.v[0];
 	vector.v[1] = matrix.m[1][3] + vec.v[1];
@@ -29,7 +29,7 @@ vr::HmdVector3_t CombinePosition(const vr::HmdMatrix34_t& matrix, const vr::HmdV
 }
 
 vr::HmdQuaternion_t GetRotation(const vr::HmdMatrix34_t& matrix) {
-	vr::HmdQuaternion_t q;
+	vr::HmdQuaternion_t q{};
 
 	q.w = sqrt(fmax(0, 1 + matrix.m[0][0] + matrix.m[1][1] + matrix.m[2][2])) / 2;
 	q.x = sqrt(fmax(0, 1 + matrix.m[0][0] - matrix.m[1][1] - matrix.m[2][2])) / 2;
@@ -53,7 +53,7 @@ vr::HmdMatrix33_t GetRotationMatrix(const vr::HmdMatrix34_t& matrix) {
 	return result;
 }
 vr::HmdVector3_t MultiplyMatrix(const vr::HmdMatrix33_t& matrix, const vr::HmdVector3_t& vector) {
-	vr::HmdVector3_t result;
+	vr::HmdVector3_t result{};
 
 	result.v[0] = matrix.m[0][0] * vector.v[0] + matrix.m[0][1] * vector.v[1] + matrix.m[0][2] * vector.v[2];
 	result.v[1] = matrix.m[1][0] * vector.v[0] + matrix.m[1][1] * vector.v[1] + matrix.m[1][2] * vector.v[2];
@@ -86,9 +86,9 @@ vr::HmdQuaternion_t QuaternionFromAngle(const double& xx, const double& yy, cons
 vr::HmdMatrix33_t QuaternionToMatrix(const vr::HmdQuaternion_t q) {
 	
 	vr::HmdMatrix33_t result = { {
-		{1 - 2*q.y*q.y - 2*q.z*q.z, 2*q.x*q.y - 2*q.z*q.w, 2*q.x*q.z + 2*q.y*q.w},
-		{2*q.x*q.y + 2*q.z*q.w, 1 - 2*q.x*q.x - 2 * q.z*q.z, 2*q.y*q.z - 2*q.x*q.w},
-		{2*q.x*q.z - 2*q.y*q.w, 2*q.y*q.z + 2*q.x*q.w, 1 - 2*q.x*q.x - 2*q.y*q.y}
+		{(float)(1 - 2*q.y*q.y - 2*q.z*q.z), (float)(2*q.x*q.y - 2*q.z*q.w), (float)(2*q.x*q.z + 2*q.y*q.w)},
+		{(float)(2*q.x*q.y + 2*q.z*q.w), (float)(1 - 2*q.x*q.x - 2 * q.z*q.z), (float)(2*q.y*q.z - 2*q.x*q.w)},
+		{(float)(2*q.x*q.z - 2*q.y*q.w), (float)(2*q.y*q.z + 2*q.x*q.w), (float)(1 - 2*q.x*q.x - 2*q.y*q.y)}
 		} };
 
 	return result;
@@ -104,7 +104,7 @@ vr::HmdQuaternion_t QuatConjugate(const vr::HmdQuaternion_t q) {
 }
 
 vr::HmdQuaternion_t MultiplyQuaternion(const vr::HmdQuaternion_t& q, const vr::HmdQuaternion_t& r) {
-	vr::HmdQuaternion_t result;
+	vr::HmdQuaternion_t result{};
 
 	result.w = (r.w * q.w - r.x * q.x - r.y * q.y - r.z * q.z);
 	result.x = (r.w * q.x + r.x * q.w - r.y * q.z + r.z * q.y);
@@ -123,7 +123,7 @@ vr::HmdQuaternion_t EulerToQuaternion(const double& yaw, const double& pitch, co
 	double cr = cos(roll * 0.5);
 	double sr = sin(roll * 0.5);
 
-	vr::HmdQuaternion_t q;
+	vr::HmdQuaternion_t q{};
 	q.w = cr * cp * cy + sr * sp * sy;
 	q.x = sr * cp * cy - cr * sp * sy;
 	q.y = cr * sp * cy + sr * cp * sy;
@@ -132,24 +132,24 @@ vr::HmdQuaternion_t EulerToQuaternion(const double& yaw, const double& pitch, co
 	return q;
 }
 vr::HmdVector3_t QuaternionToEuler(vr::HmdQuaternion_t q) {
-	vr::HmdVector3_t angles;
+	vr::HmdVector3_t angles{};
 
 	// roll (x-axis rotation)
 	double sinr_cosp = 2 * (q.w * q.x + q.y * q.z);
 	double cosr_cosp = 1 - 2 * (q.x * q.x + q.y * q.y);
-	angles.v[0] = std::atan2(sinr_cosp, cosr_cosp);
+	angles.v[0] = (float)std::atan2(sinr_cosp, cosr_cosp);
 
 	// pitch (y-axis rotation)
 	double sinp = 2 * (q.w * q.y - q.z * q.x);
 	if (std::abs(sinp) >= 1)
-		angles.v[1] = std::copysign(M_PI / 2, sinp); // use 90 degrees if out of range
+		angles.v[1] = (float)std::copysign(M_PI / 2, sinp); // use 90 degrees if out of range
 	else
-		angles.v[1] = std::asin(sinp);
+		angles.v[1] = (float)std::asin(sinp);
 
 	// yaw (z-axis rotation)
 	double siny_cosp = 2 * (q.w * q.z + q.x * q.y);
 	double cosy_cosp = 1 - 2 * (q.y * q.y + q.z * q.z);
-	angles.v[2] = std::atan2(siny_cosp, cosy_cosp);
-	vr::HmdVector3_t result = { RadToDeg(angles.v[2]), RadToDeg(angles.v[1]), RadToDeg(angles.v[0]) };
+	angles.v[2] = (float)std::atan2(siny_cosp, cosy_cosp);
+	vr::HmdVector3_t result = { (float)RadToDeg(angles.v[2]), (float)RadToDeg(angles.v[1]), (float)RadToDeg(angles.v[0]) };
 	return result;
 }


### PR DESCRIPTION
A lot of minor tweaks like adding explicit casting, and one bigger tweak: Added an enum for storing the `'A'`/`'B'` values instead of hard-coding everywhere