### PR TITLE
Updated vrsettings logic to use new section suffix

### DIFF
--- a/include/Communication/BTSerialCommunicationManager.h
+++ b/include/Communication/BTSerialCommunicationManager.h
@@ -16,6 +16,8 @@
 #include "DeviceConfiguration.h"
 #include "DriverLog.h"
 
+static const char* c_btSerialCommunicationSettingsSection = OPENGLOVES_SECTION_PREFIX "communication_btserial";
+
 class BTSerialCommunicationManager : public ICommunicationManager {
  public:
   BTSerialCommunicationManager(const VRBTSerialConfiguration_t& configuration, std::unique_ptr<IEncodingManager> encodingManager);

--- a/include/Communication/BTSerialCommunicationManager.h
+++ b/include/Communication/BTSerialCommunicationManager.h
@@ -16,7 +16,8 @@
 #include "DeviceConfiguration.h"
 #include "DriverLog.h"
 
-static const char* c_btSerialCommunicationSettingsSection = OPENGLOVES_SECTION_PREFIX "communication_btserial";
+#define BTSERIAL_COMMUNICATION_SETTINGS_SECTION_WITHOUT_PREFIX "communication_btserial"
+#define BTSERIAL_COMMUNICATION_SETTINGS_SECTION (OPENGLOVES_SECTION_PREFIX BTSERIAL_COMMUNICATION_SETTINGS_SECTION_WITHOUT_PREFIX)
 
 class BTSerialCommunicationManager : public ICommunicationManager {
  public:

--- a/include/Communication/SerialCommunicationManager.h
+++ b/include/Communication/SerialCommunicationManager.h
@@ -11,6 +11,8 @@
 #include "CommunicationManager.h"
 #include "DeviceConfiguration.h"
 
+static const char* c_serialCommunicationSettingsSection = OPENGLOVES_SECTION_PREFIX "communication_serial";
+
 class SerialCommunicationManager : public ICommunicationManager {
  public:
   SerialCommunicationManager(const VRSerialConfiguration_t& configuration, std::unique_ptr<IEncodingManager> encodingManager)

--- a/include/Communication/SerialCommunicationManager.h
+++ b/include/Communication/SerialCommunicationManager.h
@@ -11,7 +11,8 @@
 #include "CommunicationManager.h"
 #include "DeviceConfiguration.h"
 
-static const char* c_serialCommunicationSettingsSection = OPENGLOVES_SECTION_PREFIX "communication_serial";
+#define SERIAL_COMMUNICATION_SETTINGS_SECTION_WITHOUT_PREFIX "communication_serial"
+#define SERIAL_COMMUNICATION_SETTINGS_SECTION (OPENGLOVES_SECTION_PREFIX SERIAL_COMMUNICATION_SETTINGS_SECTION_WITHOUT_PREFIX)
 
 class SerialCommunicationManager : public ICommunicationManager {
  public:

--- a/include/DeviceConfiguration.h
+++ b/include/DeviceConfiguration.h
@@ -6,8 +6,12 @@
 #include "openvr_driver.h"
 
 #define OPENGLOVES_SECTION_PREFIX "opengloves."
-static const char *c_driverSettingsSection = OPENGLOVES_SECTION_PREFIX "driver_openglove";
-static const char *c_poseSettingsSection = OPENGLOVES_SECTION_PREFIX "pose_settings";
+
+#define DRIVER_SETTINGS_SECTION_WITHOUT_PREFIX "driver_openglove"
+#define DRIVER_SETTINGS_SECTION (OPENGLOVES_SECTION_PREFIX DRIVER_SETTINGS_SECTION_WITHOUT_PREFIX)
+
+#define POSE_SETTINGS_SECTION_WITHOUT_PREFIX "pose_settings"
+#define POSE_SETTINGS_SECTION (OPENGLOVES_SECTION_PREFIX POSE_SETTINGS_SECTION_WITHOUT_PREFIX)
 
 enum class VRCommunicationProtocol {
 	SERIAL = 0,

--- a/include/DeviceConfiguration.h
+++ b/include/DeviceConfiguration.h
@@ -5,8 +5,9 @@
 #include "Encode/EncodingManager.h"
 #include "openvr_driver.h"
 
-static const char *c_driverSettingsSection = "driver_openglove";
-static const char *c_poseSettingsSection = "pose_settings";
+#define OPENGLOVES_SECTION_PREFIX "opengloves."
+static const char *c_driverSettingsSection = OPENGLOVES_SECTION_PREFIX "driver_openglove";
+static const char *c_poseSettingsSection = OPENGLOVES_SECTION_PREFIX "pose_settings";
 
 enum class VRCommunicationProtocol {
 	SERIAL = 0,

--- a/include/DeviceDriver/KnuckleDriver.h
+++ b/include/DeviceDriver/KnuckleDriver.h
@@ -13,7 +13,8 @@
 #include "Encode/LegacyEncodingManager.h"
 #include "ForceFeedback.h"
 
-static const char* c_knuckleDeviceSettingsSection = OPENGLOVES_SECTION_PREFIX "device_knuckles";
+#define KNUCKLE_DEVICE_SETTINGS_SECTION_WITHOUT_PREFIX "device_knuckles"
+#define KNUCKLE_DEVICE_SETTINGS_SECTION (OPENGLOVES_SECTION_PREFIX KNUCKLE_DEVICE_SETTINGS_SECTION_WITHOUT_PREFIX)
 
 class KnuckleDeviceDriver : public IDeviceDriver {
  public:

--- a/include/DeviceDriver/KnuckleDriver.h
+++ b/include/DeviceDriver/KnuckleDriver.h
@@ -13,6 +13,8 @@
 #include "Encode/LegacyEncodingManager.h"
 #include "ForceFeedback.h"
 
+static const char* c_knuckleDeviceSettingsSection = OPENGLOVES_SECTION_PREFIX "device_knuckles";
+
 class KnuckleDeviceDriver : public IDeviceDriver {
  public:
   KnuckleDeviceDriver(VRDeviceConfiguration_t configuration, std::unique_ptr<ICommunicationManager> communicationManager, std::string serialNumber);

--- a/include/DeviceDriver/LucidGloveDriver.h
+++ b/include/DeviceDriver/LucidGloveDriver.h
@@ -12,7 +12,8 @@
 #include "ControllerPose.h"
 #include "DeviceConfiguration.h"
 
-static const char* c_lucideGloveDeviceSettingsSection = OPENGLOVES_SECTION_PREFIX "device_lucidgloves";
+#define LUCIDGLOVE_DEVICE_SETTINGS_SECTION_WITHOUT_PREFIX "device_lucidgloves"
+#define LUCIDGLOVE_DEVICE_SETTINGS_SECTION (OPENGLOVES_SECTION_PREFIX LUCIDGLOVE_DEVICE_SETTINGS_SECTION_WITHOUT_PREFIX)
 
 /**
 This class controls the behavior of the controller. This is where you

--- a/include/DeviceDriver/LucidGloveDriver.h
+++ b/include/DeviceDriver/LucidGloveDriver.h
@@ -12,6 +12,8 @@
 #include "ControllerPose.h"
 #include "DeviceConfiguration.h"
 
+static const char* c_lucideGloveDeviceSettingsSection = OPENGLOVES_SECTION_PREFIX "device_lucidgloves";
+
 /**
 This class controls the behavior of the controller. This is where you
 tell OpenVR what your controller has (buttons, joystick, trackpad, etc.).

--- a/include/Encode/AlphaEncodingManager.h
+++ b/include/Encode/AlphaEncodingManager.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "DeviceConfiguration.h"
 #include "Encode/EncodingManager.h"
+
+static const char* c_alphaEncodingSettingsSection = OPENGLOVES_SECTION_PREFIX "encoding_alpha";
 
 class AlphaEncodingManager : public IEncodingManager {
 public:

--- a/include/Encode/AlphaEncodingManager.h
+++ b/include/Encode/AlphaEncodingManager.h
@@ -3,7 +3,8 @@
 #include "DeviceConfiguration.h"
 #include "Encode/EncodingManager.h"
 
-static const char* c_alphaEncodingSettingsSection = OPENGLOVES_SECTION_PREFIX "encoding_alpha";
+#define ALPHA_ENCODING_SETTINGS_SECTION_WITHOUT_PREFIX "encoding_alpha"
+#define ALPHA_ENCODING_SETTINGS_SECTION (OPENGLOVES_SECTION_PREFIX ALPHA_ENCODING_SETTINGS_SECTION_WITHOUT_PREFIX)
 
 class AlphaEncodingManager : public IEncodingManager {
 public:

--- a/include/Encode/LegacyEncodingManager.h
+++ b/include/Encode/LegacyEncodingManager.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include "DeviceConfiguration.h"
 #include <Encode/EncodingManager.h>
 #include "ForceFeedback.h"
+
+static const char* c_legacyEncodingSettingsSection = OPENGLOVES_SECTION_PREFIX "encoding_legacy";
 
 class LegacyEncodingManager : public IEncodingManager {
  public:

--- a/include/Encode/LegacyEncodingManager.h
+++ b/include/Encode/LegacyEncodingManager.h
@@ -4,7 +4,8 @@
 #include <Encode/EncodingManager.h>
 #include "ForceFeedback.h"
 
-static const char* c_legacyEncodingSettingsSection = OPENGLOVES_SECTION_PREFIX "encoding_legacy";
+#define LEGACY_ENCODING_SETTINGS_SECTION_WITHOUT_PREFIX "encoding_legacy"
+#define LEGACY_ENCODING_SETTINGS_SECTION (OPENGLOVES_SECTION_PREFIX LEGACY_ENCODING_SETTINGS_SECTION_WITHOUT_PREFIX)
 
 class LegacyEncodingManager : public IEncodingManager {
  public:

--- a/openglove/resources/settings/default.vrsettings
+++ b/openglove/resources/settings/default.vrsettings
@@ -1,5 +1,5 @@
 {
-  "driver_openglove":
+  "opengloves.driver_openglove":
   {
     "__title": "OpenGlove Configuration",
     "left_enabled": true,
@@ -8,21 +8,21 @@
     "device_driver": 1, //title:Device Driver Emulation
     "encoding_protocol": 1 //title:Encoding Protocol
   },
-  "device_lucidgloves":
+  "opengloves.device_lucidgloves":
   {
     "__title": "Lucid Glove",
     "__type": "device_driver:0",
     "left_serial_number": "lucidgloves-left",
     "right_serial_number": "lucidgloves-right"
   },
-  "device_knuckles":
+  "opengloves.device_knuckles":
   {
     "__title": "Knuckles Emulation",
     "__type": "device_driver:1",
     "left_serial_number": "LHR-E217CD00",
     "right_serial_number": "LHR-E217CD01"
   },
-  "pose_settings":
+  "opengloves.pose_settings":
   {
     "__title": "Pose settings",
     "right_x_offset_position": -0.1,
@@ -42,7 +42,7 @@
     "controller_override_left": 3,
     "controller_override_right": 4
   },
-  "communication_serial":
+  "opengloves.communication_serial":
   {
     "__type": "communication_protocol:0",
     "__title": "USB Serial",
@@ -50,20 +50,20 @@
     "right_port": "\\\\.\\COM5",
     "baud_rate": 115200
   },
-  "communication_btserial": 
+  "opengloves.communication_btserial": 
   {
     "__type": "communication_protocol:1",
     "__title": "Bluetooth Serial",
 	"left_name": "lucidgloves-left",
   	"right_name": "lucidgloves-right"
   },
-  "encoding_legacy":
+  "opengloves.encoding_legacy":
   {
     "__type": "encoding_protocol: 0",
     "__title": "Legacy Encoding",
     "max_analog_value": 1023
   },
-  "encoding_alpha":
+  "opengloves.encoding_alpha":
   {
     "__type": "encoding_protocol: 1",
     "__title": "Alpha Protocol",

--- a/src/Calibration.cpp
+++ b/src/Calibration.cpp
@@ -47,15 +47,15 @@ VRPoseConfiguration_t Calibration::FinishCalibration(vr::TrackedDevicePose_t con
 
     poseConfiguration.offsetVector = transformVector;
 
-    vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_x_offset_position" : "left_x_offset_position", transformVector.v[0]);
-    vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_y_offset_position" : "left_y_offset_position", transformVector.v[1]);
-    vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_z_offset_position" : "left_z_offset_position", transformVector.v[2]);
+    vr::VRSettings()->SetFloat(POSE_SETTINGS_SECTION, isRightHand ? "right_x_offset_position" : "left_x_offset_position", transformVector.v[0]);
+    vr::VRSettings()->SetFloat(POSE_SETTINGS_SECTION, isRightHand ? "right_y_offset_position" : "left_y_offset_position", transformVector.v[1]);
+    vr::VRSettings()->SetFloat(POSE_SETTINGS_SECTION, isRightHand ? "right_z_offset_position" : "left_z_offset_position", transformVector.v[2]);
 
     vr::HmdVector3_t eulerOffset = QuaternionToEuler(transformQuat);
 
-    vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_x_offset_degrees" : "left_x_offset_degrees", eulerOffset.v[0]);
-    vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_y_offset_degrees" : "left_y_offset_degrees", eulerOffset.v[1]);
-    vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_z_offset_degrees" : "left_z_offset_degrees", eulerOffset.v[2]);
+    vr::VRSettings()->SetFloat(POSE_SETTINGS_SECTION, isRightHand ? "right_x_offset_degrees" : "left_x_offset_degrees", eulerOffset.v[0]);
+    vr::VRSettings()->SetFloat(POSE_SETTINGS_SECTION, isRightHand ? "right_y_offset_degrees" : "left_y_offset_degrees", eulerOffset.v[1]);
+    vr::VRSettings()->SetFloat(POSE_SETTINGS_SECTION, isRightHand ? "right_z_offset_degrees" : "left_z_offset_degrees", eulerOffset.v[2]);
 
     return poseConfiguration;
 }

--- a/src/Communication/SerialCommunicationManager.cpp
+++ b/src/Communication/SerialCommunicationManager.cpp
@@ -93,7 +93,9 @@ void SerialCommunicationManager::ListenerThread(const std::function<void(VRCommD
             continue;
         }
         catch (const std::invalid_argument& ia) {
-            LogMessage(strcat("Received error from encoding manager: ", ia.what()));
+            char message[1024] = { 0 };
+            sprintf_s(message, "Received error from encoding manager: %s", ia.what());
+            LogMessage(message);
         }
     }
     LogMessage("Detected device error. Disconnecting device and attempting reconnection");

--- a/src/DeviceProvider.cpp
+++ b/src/DeviceProvider.cpp
@@ -98,15 +98,14 @@ std::unique_ptr<IDeviceDriver> DeviceProvider::InstantiateDeviceDriver(
   switch (configuration.encodingProtocol) {
     default:
       DriverLog("No encoding protocol set. Using legacy.");
-      // fall through
     case VREncodingProtocol::LEGACY: {
-      const float maxAnalogValue = vr::VRSettings()->GetFloat("encoding_legacy", "max_analog_value");
+      const float maxAnalogValue = vr::VRSettings()->GetFloat(c_legacyEncodingSettingsSection, "max_analog_value");
       encodingManager = std::make_unique<LegacyEncodingManager>(maxAnalogValue);
       break;
     }
     case VREncodingProtocol::ALPHA: {
       const float maxAnalogValue =
-          vr::VRSettings()->GetFloat("encoding_alpha", "max_analog_value");  //
+          vr::VRSettings()->GetFloat(c_alphaEncodingSettingsSection, "max_analog_value");  //
       encodingManager = std::make_unique<AlphaEncodingManager>(maxAnalogValue);
       break;
     }
@@ -116,7 +115,7 @@ std::unique_ptr<IDeviceDriver> DeviceProvider::InstantiateDeviceDriver(
     case VRCommunicationProtocol::BTSERIAL: {
       DriverLog("Communication set to BTSerial");
       char name[248];
-      vr::VRSettings()->GetString("communication_btserial",
+      vr::VRSettings()->GetString(c_btSerialCommunicationSettingsSection,
                                   isRightHand ? "right_name" : "left_name", name, sizeof(name));
       VRBTSerialConfiguration_t btSerialSettings(name);
       communicationManager = std::make_unique<BTSerialCommunicationManager>(
@@ -125,12 +124,11 @@ std::unique_ptr<IDeviceDriver> DeviceProvider::InstantiateDeviceDriver(
     }
     default:
       DriverLog("No communication protocol set. Using serial.");
-      // fall through
     case VRCommunicationProtocol::SERIAL:
       char port[16];
-      vr::VRSettings()->GetString("communication_serial", isRightHand ? "right_port" : "left_port",
+      vr::VRSettings()->GetString(c_serialCommunicationSettingsSection, isRightHand ? "right_port" : "left_port",
                                   port, sizeof(port));
-      const int baudRate = vr::VRSettings()->GetInt32("communication_serial", "baud_rate");
+      const int baudRate = vr::VRSettings()->GetInt32(c_serialCommunicationSettingsSection, "baud_rate");
       VRSerialConfiguration_t serialSettings(port, baudRate);
 
       communicationManager =
@@ -141,7 +139,7 @@ std::unique_ptr<IDeviceDriver> DeviceProvider::InstantiateDeviceDriver(
   switch (configuration.deviceDriver) {
     case VRDeviceDriver::EMULATED_KNUCKLES: {
       char serialNumber[32];
-      vr::VRSettings()->GetString("device_knuckles",
+      vr::VRSettings()->GetString(c_knuckleDeviceSettingsSection,
                                   isRightHand ? "right_serial_number" : "left_serial_number",
                                   serialNumber, sizeof(serialNumber));
 
@@ -151,10 +149,9 @@ std::unique_ptr<IDeviceDriver> DeviceProvider::InstantiateDeviceDriver(
 
     default:
       DriverLog("No device driver selected. Using lucidgloves.");
-      // fall through
     case VRDeviceDriver::LUCIDGLOVES: {
       char serialNumber[32];
-      vr::VRSettings()->GetString("device_lucidgloves",
+      vr::VRSettings()->GetString(c_lucideGloveDeviceSettingsSection,
                                   isRightHand ? "right_serial_number" : "left_serial_number",
                                   serialNumber, sizeof(serialNumber));
 

--- a/src/DeviceProvider.cpp
+++ b/src/DeviceProvider.cpp
@@ -271,7 +271,7 @@ static bool TryGetDeviceConfiguration(vr::ETrackedControllerRole role, bool with
   return true;
 }
 VRDeviceConfiguration_t DeviceProvider::GetDeviceConfiguration(vr::ETrackedControllerRole role) {
-  VRDeviceConfiguration_t config{};
+  VRDeviceConfiguration_t config({}, false, {{}, {}, {}, false, 0}, {}, {}, {});
   if (!TryGetDeviceConfiguration(role, false, &config))
     TryGetDeviceConfiguration(role, true, &config);
   return config;


### PR DESCRIPTION
Updated the shipping file along with any reference to section keys in code to use `opengloves.` as a prefix. Also updated section references to be constants rather than string literals.

This is to be paired with LucidVR/opengloves-ui#6 to address #129 