### PR TITLE
Make 4095 the default analog max

### DIFF
--- a/openglove/resources/settings/default.vrsettings
+++ b/openglove/resources/settings/default.vrsettings
@@ -61,12 +61,12 @@
   {
     "__type": "encoding_protocol: 0",
     "__title": "Legacy Encoding",
-    "max_analog_value": 1023
+    "max_analog_value": 4095
   },
   "encoding_alpha":
   {
     "__type": "encoding_protocol: 1",
     "__title": "Alpha Protocol",
-    "max_analog_value": 1023
+    "max_analog_value": 4095
   }
 }


### PR DESCRIPTION
Results for this based on the poll in the discord server. 
As of 12 minutes into the poll, 31 people voted for 4095 as analog max, 3 people voted for 1023 as default