### PR TITLE
Pose calibration bugfix

### DIFF
--- a/include/Calibration.h
+++ b/include/Calibration.h
@@ -1,23 +1,28 @@
 #pragma once
-#include <openvr_driver.h>
+#include "openvr_driver.h"
+
 #include <memory>
+
 #include "DeviceConfiguration.h"
 
+enum class CalibrationMethod { HARDWARE, UI, NONE };
+
 class Calibration {
-public:
-    Calibration();
+ public:
+  Calibration();
 
-    void StartCalibration(vr::DriverPose_t maintainPose);
+  void StartCalibration(vr::DriverPose_t maintainPose, CalibrationMethod method);
 
-    VRPoseConfiguration_t CompleteCalibration(vr::TrackedDevicePose_t controllerPose, VRPoseConfiguration_t poseConfiguration, bool isRightHand);
+  VRPoseConfiguration_t CompleteCalibration(vr::TrackedDevicePose_t controllerPose, VRPoseConfiguration_t poseConfiguration, bool isRightHand, CalibrationMethod method);
 
-    void CancelCalibration();
+  void CancelCalibration(CalibrationMethod method);
 
-    bool isCalibrating();
-    
-    vr::DriverPose_t GetMaintainPose();
+  bool isCalibrating();
 
-private:
-    vr::DriverPose_t m_maintainPose;
-    bool m_isCalibrating;
+  vr::DriverPose_t GetMaintainPose();
+
+ private:
+  vr::DriverPose_t m_maintainPose;
+  bool m_isCalibrating;
+  CalibrationMethod m_calibratingMethod;
 };

--- a/include/ControllerPose.h
+++ b/include/ControllerPose.h
@@ -19,11 +19,11 @@ class ControllerPose {
 
   vr::DriverPose_t UpdatePose();
 
-  void StartCalibration();
+  void StartCalibration(CalibrationMethod method);
 
-  void CompleteCalibration();
+  void CompleteCalibration(CalibrationMethod method);
 
-  void CancelCalibration();
+  void CancelCalibration(CalibrationMethod method);
 
   bool isCalibrating();
 

--- a/include/DeviceConfiguration.h
+++ b/include/DeviceConfiguration.h
@@ -43,17 +43,19 @@ struct VRBTSerialConfiguration_t {
 
 struct VRPoseConfiguration_t {
   VRPoseConfiguration_t(vr::HmdVector3_t offsetVector, vr::HmdQuaternion_t angleOffsetQuaternion, float poseTimeOffset, bool controllerOverrideEnabled,
-                        int controllerIdOverride)
+                        int controllerIdOverride, bool calibrationButtonEnabled)
       : offsetVector(offsetVector),
         angleOffsetQuaternion(angleOffsetQuaternion),
         poseTimeOffset(poseTimeOffset),
         controllerOverrideEnabled(controllerOverrideEnabled),
-        controllerIdOverride(controllerIdOverride){};
+        controllerIdOverride(controllerIdOverride),
+        calibrationButtonEnabled(calibrationButtonEnabled){};
   vr::HmdVector3_t offsetVector;
   vr::HmdQuaternion_t angleOffsetQuaternion;
   float poseTimeOffset;
   int controllerIdOverride;
   bool controllerOverrideEnabled;
+  bool calibrationButtonEnabled;
 };
 
 struct VRDeviceConfiguration_t {

--- a/openglove/resources/settings/default.vrsettings
+++ b/openglove/resources/settings/default.vrsettings
@@ -40,7 +40,8 @@
     "pose_time_offset": -0.01,
     "controller_override": false,
     "controller_override_left": 3,
-    "controller_override_right": 4
+    "controller_override_right": 4,
+    "hardware_calibration_button_enabled": false
   },
   "communication_serial":
   {

--- a/src/Calibration.cpp
+++ b/src/Calibration.cpp
@@ -3,67 +3,66 @@
 #include "DriverLog.h"
 #include "Quaternion.h"
 
-Calibration::Calibration() : m_maintainPose(), m_isCalibrating(false) {}
+Calibration::Calibration() : m_maintainPose(), m_isCalibrating(false), m_calibratingMethod(CalibrationMethod::NONE) {}
 
-void Calibration::StartCalibration(vr::DriverPose_t maintainPose) {
-    maintainPose.vecVelocity[0] = 0;
-    maintainPose.vecVelocity[1] = 0;
-    maintainPose.vecVelocity[2] = 0;
-    maintainPose.vecAngularVelocity[0] = 0;
-    maintainPose.vecAngularVelocity[1] = 0;
-    maintainPose.vecAngularVelocity[2] = 0;
-    m_maintainPose = maintainPose;  
-    m_isCalibrating = true;
+void Calibration::StartCalibration(vr::DriverPose_t maintainPose, CalibrationMethod method) {
+  m_calibratingMethod = method;
+
+  maintainPose.vecVelocity[0] = 0;
+  maintainPose.vecVelocity[1] = 0;
+  maintainPose.vecVelocity[2] = 0;
+  maintainPose.vecAngularVelocity[0] = 0;
+  maintainPose.vecAngularVelocity[1] = 0;
+  maintainPose.vecAngularVelocity[2] = 0;
+  m_maintainPose = maintainPose;
+  m_isCalibrating = true;
 }
 
-VRPoseConfiguration_t Calibration::CompleteCalibration(vr::TrackedDevicePose_t controllerPose, VRPoseConfiguration_t poseConfiguration, bool isRightHand) {
-    
-    m_isCalibrating = false;
-    // get the matrix that represents the position of the controller that we are shadowing
-    vr::HmdMatrix34_t controllerMatrix = controllerPose.mDeviceToAbsoluteTracking;
+VRPoseConfiguration_t Calibration::CompleteCalibration(vr::TrackedDevicePose_t controllerPose, VRPoseConfiguration_t poseConfiguration, bool isRightHand,
+                                                       CalibrationMethod method) {
+  if (m_calibratingMethod != method) return poseConfiguration;
+  m_isCalibrating = false;
+  // get the matrix that represents the position of the controller that we are shadowing
+  vr::HmdMatrix34_t controllerMatrix = controllerPose.mDeviceToAbsoluteTracking;
 
-    vr::HmdQuaternion_t controllerQuat = GetRotation(controllerMatrix);
-    vr::HmdQuaternion_t handQuat = m_maintainPose.qRotation;
-    
+  vr::HmdQuaternion_t controllerQuat = GetRotation(controllerMatrix);
+  vr::HmdQuaternion_t handQuat = m_maintainPose.qRotation;
 
-    //qC * qT = qH   -> qC*qC^-1 * qT = qH * qC^-1   -> qT = qH * qC^-1
-    vr::HmdQuaternion_t transformQuat = MultiplyQuaternion(QuatConjugate(controllerQuat), handQuat);
-    //m_poseConfiguration.angleOffsetQuaternion = transformQuat;
-    poseConfiguration.angleOffsetQuaternion.w = transformQuat.w;
-    poseConfiguration.angleOffsetQuaternion.x = transformQuat.x;
-    poseConfiguration.angleOffsetQuaternion.y = transformQuat.y;
-    poseConfiguration.angleOffsetQuaternion.z = transformQuat.z;
+  // qC * qT = qH   -> qC*qC^-1 * qT = qH * qC^-1   -> qT = qH * qC^-1
+  vr::HmdQuaternion_t transformQuat = MultiplyQuaternion(QuatConjugate(controllerQuat), handQuat);
 
-    vr::HmdVector3_t differenceVector = { (float)(m_maintainPose.vecPosition[0] - controllerMatrix.m[0][3]),
-                                          (float)(m_maintainPose.vecPosition[1] - controllerMatrix.m[1][3]),
-                                          (float)(m_maintainPose.vecPosition[2] - controllerMatrix.m[2][3]) };
+  poseConfiguration.angleOffsetQuaternion.w = transformQuat.w;
+  poseConfiguration.angleOffsetQuaternion.x = transformQuat.x;
+  poseConfiguration.angleOffsetQuaternion.y = transformQuat.y;
+  poseConfiguration.angleOffsetQuaternion.z = transformQuat.z;
 
-    vr::HmdQuaternion_t transformInverse = QuatConjugate(controllerQuat);
-    vr::HmdMatrix33_t transformMatrix = QuaternionToMatrix(transformInverse);
-    vr::HmdVector3_t transformVector = MultiplyMatrix(transformMatrix, differenceVector);
+  vr::HmdVector3_t differenceVector = {(float)(m_maintainPose.vecPosition[0] - controllerMatrix.m[0][3]),
+                                       (float)(m_maintainPose.vecPosition[1] - controllerMatrix.m[1][3]),
+                                       (float)(m_maintainPose.vecPosition[2] - controllerMatrix.m[2][3])};
 
-    poseConfiguration.offsetVector = transformVector;
+  vr::HmdQuaternion_t transformInverse = QuatConjugate(controllerQuat);
+  vr::HmdMatrix33_t transformMatrix = QuaternionToMatrix(transformInverse);
+  vr::HmdVector3_t transformVector = MultiplyMatrix(transformMatrix, differenceVector);
 
-    vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_x_offset_position" : "left_x_offset_position", transformVector.v[0]);
-    vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_y_offset_position" : "left_y_offset_position", transformVector.v[1]);
-    vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_z_offset_position" : "left_z_offset_position", transformVector.v[2]);
+  poseConfiguration.offsetVector = transformVector;
 
-    vr::HmdVector3_t eulerOffset = QuaternionToEuler(transformQuat);
+  vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_x_offset_position" : "left_x_offset_position", transformVector.v[0]);
+  vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_y_offset_position" : "left_y_offset_position", transformVector.v[1]);
+  vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_z_offset_position" : "left_z_offset_position", transformVector.v[2]);
 
-    vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_x_offset_degrees" : "left_x_offset_degrees", eulerOffset.v[0]);
-    vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_y_offset_degrees" : "left_y_offset_degrees", eulerOffset.v[1]);
-    vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_z_offset_degrees" : "left_z_offset_degrees", eulerOffset.v[2]);
+  vr::HmdVector3_t eulerOffset = QuaternionToEuler(transformQuat);
 
-    return poseConfiguration;
+  vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_x_offset_degrees" : "left_x_offset_degrees", eulerOffset.v[0]);
+  vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_y_offset_degrees" : "left_y_offset_degrees", eulerOffset.v[1]);
+  vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_z_offset_degrees" : "left_z_offset_degrees", eulerOffset.v[2]);
+
+  return poseConfiguration;
 }
 
-void Calibration::CancelCalibration() { m_isCalibrating = false; }
-
-bool Calibration::isCalibrating() {
-    return m_isCalibrating;
+void Calibration::CancelCalibration(CalibrationMethod method) {
+  if (m_calibratingMethod == method) m_isCalibrating = false;
 }
 
-vr::DriverPose_t Calibration::GetMaintainPose() {
-    return m_maintainPose;
-}
+bool Calibration::isCalibrating() { return m_isCalibrating; }
 
+vr::DriverPose_t Calibration::GetMaintainPose() { return m_maintainPose; }

--- a/src/ControllerPose.cpp
+++ b/src/ControllerPose.cpp
@@ -12,10 +12,10 @@ ControllerPose::ControllerPose(vr::ETrackedControllerRole shadowDeviceOfRole, st
   m_calibrationPipe->StartListening([&](CalibrationDataIn* data) {
     if (data->start) {
       DriverLog("Starting calibration via external application");
-      StartCalibration();
+      StartCalibration(CalibrationMethod::UI);
     } else {
       DriverLog("Stopping calibration via external application");
-      CompleteCalibration();
+      CompleteCalibration(CalibrationMethod::UI);
     }
   });
 
@@ -104,18 +104,18 @@ vr::DriverPose_t ControllerPose::UpdatePose() {
   return newPose;
 }
 
-void ControllerPose::StartCalibration() { m_calibration->StartCalibration(UpdatePose()); }
+void ControllerPose::StartCalibration(CalibrationMethod method) { m_calibration->StartCalibration(UpdatePose(), method); }
 
-void ControllerPose::CompleteCalibration() {
+void ControllerPose::CompleteCalibration(CalibrationMethod method) {
   if (m_shadowControllerId == vr::k_unTrackedDeviceIndexInvalid) {
     DriverLog("Index invalid");
-    CancelCalibration();
+    CancelCalibration(method);
     return;
   }
-  m_poseConfiguration = m_calibration->CompleteCalibration(GetControllerPose(), m_poseConfiguration, isRightHand());
+  m_poseConfiguration = m_calibration->CompleteCalibration(GetControllerPose(), m_poseConfiguration, isRightHand(), method);
 }
 
-void ControllerPose::CancelCalibration() { m_calibration->CancelCalibration(); }
+void ControllerPose::CancelCalibration(CalibrationMethod method) { m_calibration->CancelCalibration(method); }
 
 bool ControllerPose::isCalibrating() { return m_calibration->isCalibrating(); }
 

--- a/src/DeviceDriver/DeviceDriver.cpp
+++ b/src/DeviceDriver/DeviceDriver.cpp
@@ -92,10 +92,12 @@ void DeviceDriver::StartDevice() {
 
       HandleInput(datas);
 
-      if (datas.calibrate) {
-        if (!m_controllerPose->isCalibrating()) m_controllerPose->StartCalibration();
-      } else {
-        if (m_controllerPose->isCalibrating()) m_controllerPose->CompleteCalibration();
+      if (m_configuration.poseConfiguration.calibrationButtonEnabled) {
+        if (datas.calibrate) {
+          if (!m_controllerPose->isCalibrating()) m_controllerPose->StartCalibration(CalibrationMethod::HARDWARE);
+        } else {
+          if (m_controllerPose->isCalibrating()) m_controllerPose->CompleteCalibration(CalibrationMethod::HARDWARE);
+        }
       }
 
     } catch (const std::exception&) {

--- a/src/DeviceProvider.cpp
+++ b/src/DeviceProvider.cpp
@@ -151,15 +151,16 @@ VRDeviceConfiguration_t DeviceProvider::GetDeviceConfiguration(vr::ETrackedContr
   const bool controllerOverrideEnabled = vr::VRSettings()->GetBool(c_poseSettingsSection, "controller_override");
   const int controllerIdOverride =
       controllerOverrideEnabled ? vr::VRSettings()->GetInt32(c_poseSettingsSection, isRightHand ? "controller_override_right" : "controller_override_left") : -1;
+  const bool calibrationButton = vr::VRSettings()->GetBool(c_poseSettingsSection, "hardware_calibration_button_enabled");
 
   const vr::HmdVector3_t offsetVector = {offsetXPos, offsetYPos, offsetZPos};
 
   // Convert the rotation to a quaternion
   const vr::HmdQuaternion_t angleOffsetQuaternion = EulerToQuaternion(DegToRad(offsetXRot), DegToRad(offsetYRot), DegToRad(offsetZRot));
 
-  return VRDeviceConfiguration_t(role, isEnabled,
-                                 VRPoseConfiguration_t(offsetVector, angleOffsetQuaternion, poseTimeOffset, controllerOverrideEnabled, controllerIdOverride),
-                                 encodingProtocol, communicationProtocol, deviceDriver);
+  return VRDeviceConfiguration_t(
+      role, isEnabled, VRPoseConfiguration_t(offsetVector, angleOffsetQuaternion, poseTimeOffset, controllerOverrideEnabled, controllerIdOverride, calibrationButton),
+      encodingProtocol, communicationProtocol, deviceDriver);
 }
 
 void DeviceProvider::Cleanup() {}


### PR DESCRIPTION
Hardware button interacts with the calibration process if done through the UI and the pin is floating. This pr adds:

1. A config option for enabling the button for pose calibration
2. A check for making sure the same method started the calibration when ending

Some additional logging for named pipes.