### PR TITLE
Retry bluetooth send on error

### DIFF
--- a/include/Util/Logic.h
+++ b/include/Util/Logic.h
@@ -1,0 +1,6 @@
+#pragma once
+#include <functional>
+#include <chrono>
+#include <thread>
+
+bool retry(std::function<bool()> func, short attempts, short timeout);

--- a/src/Util/Logic.cpp
+++ b/src/Util/Logic.cpp
@@ -1,0 +1,14 @@
+#include "Util/Logic.h"
+
+bool retry(std::function<bool()> func, short attempts, short timeout) {
+  short retries = 0;
+
+  do {
+    if (func()) return true;
+    std::this_thread::sleep_for(std::chrono::milliseconds(timeout));
+
+    retries++;
+  } while (retries < attempts);
+
+  return false;
+}


### PR DESCRIPTION
Currently, if the send for bluetooth fails, the communication with the device will stop completely without the ability to reconnect. This PR adds in attempts to retry sending to the device at a giving interval to help prevent completely disconnecting.