### PR TITLE
Bugfix/serial rw fixes

### DIFF
--- a/include/Communication/BTSerialCommunicationManager.h
+++ b/include/Communication/BTSerialCommunicationManager.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Winsock2.h>
+#include <WinSock2.h>
 #include <bluetoothapis.h>
 
 #include <atomic>
@@ -12,29 +12,28 @@
 #include "Encode/EncodingManager.h"
 
 class BTSerialCommunicationManager : public CommunicationManager {
- public:
-  BTSerialCommunicationManager(std::unique_ptr<EncodingManager> encodingManager, const VRBTSerialConfiguration_t& configuration);
+public:
+  BTSerialCommunicationManager(
+      std::unique_ptr<EncodingManager> encodingManager,
+      VRBTSerialConfiguration_t configuration,
+      const VRDeviceConfiguration_t& deviceConfiguration);
 
- public:
-  bool IsConnected();
+  bool IsConnected() override;
 
- protected:
-  bool Connect();
-  bool DisconnectFromDevice();
-  void LogError(const char* message);
-  void LogMessage(const char* message);
-  bool ReceiveNextPacket(std::string& buff);
-  bool SendMessageToDevice();
+protected:
+  bool Connect() override;
+  bool DisconnectFromDevice() override;
+  void LogError(const char* message) override;
+  void LogMessage(const char* message) override;
+  bool ReceiveNextPacket(std::string& buff) override;
+  bool SendMessageToDevice() override;
 
- private:
+private:
   bool ConnectToDevice(BTH_ADDR& deviceBtAddress);
   bool GetPairedDeviceBtAddress(BTH_ADDR* deviceBtAddress);
   bool StartupWindowsSocket();
 
- private:
   VRBTSerialConfiguration_t m_btSerialConfiguration;
-
   std::atomic<bool> m_isConnected;
-
   std::atomic<SOCKET> m_btClientSocket;
 };

--- a/include/Communication/BTSerialCommunicationManager.h
+++ b/include/Communication/BTSerialCommunicationManager.h
@@ -12,28 +12,30 @@
 #include "Encode/EncodingManager.h"
 
 class BTSerialCommunicationManager : public CommunicationManager {
-public:
-  BTSerialCommunicationManager(
-      std::unique_ptr<EncodingManager> encodingManager,
-      VRBTSerialConfiguration_t configuration,
-      const VRDeviceConfiguration_t& deviceConfiguration);
+ public:
+  BTSerialCommunicationManager(std::unique_ptr<EncodingManager> encodingManager, VRBTSerialConfiguration_t configuration,
+                               const VRDeviceConfiguration_t& deviceConfiguration);
 
-  bool IsConnected() override;
+ public:
+  bool IsConnected();
 
-protected:
-  bool Connect() override;
-  bool DisconnectFromDevice() override;
-  void LogError(const char* message) override;
-  void LogMessage(const char* message) override;
-  bool ReceiveNextPacket(std::string& buff) override;
-  bool SendMessageToDevice() override;
+ protected:
+  bool Connect();
+  bool DisconnectFromDevice();
+  void LogError(const char* message);
+  void LogMessage(const char* message);
+  bool ReceiveNextPacket(std::string& buff);
+  bool SendMessageToDevice();
 
-private:
+ private:
   bool ConnectToDevice(BTH_ADDR& deviceBtAddress);
   bool GetPairedDeviceBtAddress(BTH_ADDR* deviceBtAddress);
   bool StartupWindowsSocket();
 
+ private:
   VRBTSerialConfiguration_t m_btSerialConfiguration;
+
   std::atomic<bool> m_isConnected;
+
   std::atomic<SOCKET> m_btClientSocket;
 };

--- a/include/Communication/BTSerialCommunicationManager.h
+++ b/include/Communication/BTSerialCommunicationManager.h
@@ -14,7 +14,7 @@
 class BTSerialCommunicationManager : public CommunicationManager {
  public:
   BTSerialCommunicationManager(std::unique_ptr<EncodingManager> encodingManager, VRBTSerialConfiguration configuration,
-                               const VRDeviceConfiguration_t& deviceConfiguration);
+                               const VRDeviceConfiguration& deviceConfiguration);
 
  public:
   bool IsConnected();

--- a/include/Communication/CommunicationManager.h
+++ b/include/Communication/CommunicationManager.h
@@ -31,6 +31,7 @@ class CommunicationManager {
   virtual bool ReceiveNextPacket(std::string& buff) = 0;
   virtual bool SendMessageToDevice() = 0;
 
+ protected:
   std::unique_ptr<EncodingManager> m_encodingManager;
   VRDeviceConfiguration_t m_deviceConfiguration;
 

--- a/include/Communication/CommunicationManager.h
+++ b/include/Communication/CommunicationManager.h
@@ -7,11 +7,12 @@
 #include <string>
 #include <thread>
 
+#include "DeviceConfiguration.h"
 #include "Encode/EncodingManager.h"
 
 class CommunicationManager {
  public:
-  CommunicationManager(std::unique_ptr<EncodingManager> encodingManager);
+  CommunicationManager(std::unique_ptr<EncodingManager> encodingManager, const VRDeviceConfiguration_t& deviceConfiguration);
 
   virtual void BeginListener(const std::function<void(VRInputData_t)>& callback);
   virtual void Disconnect();
@@ -30,8 +31,8 @@ class CommunicationManager {
   virtual bool ReceiveNextPacket(std::string& buff) = 0;
   virtual bool SendMessageToDevice() = 0;
 
- protected:
   std::unique_ptr<EncodingManager> m_encodingManager;
+  VRDeviceConfiguration_t m_deviceConfiguration;
 
   std::atomic<bool> m_threadActive;
   std::thread m_thread;

--- a/include/Communication/CommunicationManager.h
+++ b/include/Communication/CommunicationManager.h
@@ -12,8 +12,8 @@
 
 class CommunicationManager {
  public:
-  CommunicationManager(const VRDeviceConfiguration_t& deviceConfiguration) : this(nullptr, deviceConfiguration);
-  CommunicationManager(std::unique_ptr<EncodingManager> encodingManager, const VRDeviceConfiguration_t& deviceConfiguration);
+  CommunicationManager(const VRDeviceConfiguration& deviceConfiguration);
+  CommunicationManager(std::unique_ptr<EncodingManager> encodingManager, const VRDeviceConfiguration& deviceConfiguration);
 
   virtual void BeginListener(const std::function<void(VRInputData)>& callback);
   virtual void Disconnect();
@@ -34,7 +34,7 @@ class CommunicationManager {
 
  protected:
   std::unique_ptr<EncodingManager> m_encodingManager;
-  VRDeviceConfiguration_t m_deviceConfiguration;
+  VRDeviceConfiguration m_deviceConfiguration;
 
   std::atomic<bool> m_threadActive;
   std::thread m_thread;

--- a/include/Communication/NamedPipeCommunicationManager.h
+++ b/include/Communication/NamedPipeCommunicationManager.h
@@ -11,7 +11,7 @@
 class NamedPipeCommunicationManager : public CommunicationManager {
 
  public:
-  NamedPipeCommunicationManager(const VRNamedPipeInputConfiguration& configuration);
+  NamedPipeCommunicationManager(const VRNamedPipeInputConfiguration& configuration, const VRDeviceConfiguration& deviceConfiguration);
   bool IsConnected();
 
  protected:

--- a/include/Communication/SerialCommunicationManager.h
+++ b/include/Communication/SerialCommunicationManager.h
@@ -12,25 +12,26 @@
 
 class SerialCommunicationManager : public CommunicationManager {
  public:
-  SerialCommunicationManager(
-	  std::unique_ptr<EncodingManager> encodingManager,
-	  VRSerialConfiguration_t configuration,
-	  const VRDeviceConfiguration_t& deviceConfiguration);
+  SerialCommunicationManager(std::unique_ptr<EncodingManager> encodingManager, VRSerialConfiguration_t configuration, const VRDeviceConfiguration_t& deviceConfiguration);
 
-  bool IsConnected() override;
+ public:
+  bool IsConnected();
 
  protected:
-  bool Connect() override;
-  bool DisconnectFromDevice() override;
-  void LogError(const char* message) override;
-  void LogMessage(const char* message) override;
-  bool ReceiveNextPacket(std::string& buff) override;
-  bool SendMessageToDevice() override;
+  bool Connect();
+  bool DisconnectFromDevice();
+  void LogError(const char* message);
+  void LogMessage(const char* message);
+  bool ReceiveNextPacket(std::string& buff);
+  bool SendMessageToDevice();
 
  private:
   bool PurgeBuffer();
 
+ private:
   VRSerialConfiguration_t m_serialConfiguration;
+
   std::atomic<bool> m_isConnected;
+
   std::atomic<HANDLE> m_hSerial;
 };

--- a/include/Communication/SerialCommunicationManager.h
+++ b/include/Communication/SerialCommunicationManager.h
@@ -12,7 +12,7 @@
 
 class SerialCommunicationManager : public CommunicationManager {
  public:
-  SerialCommunicationManager(std::unique_ptr<EncodingManager> encodingManager, VRSerialConfiguration_t configuration, const VRDeviceConfiguration_t& deviceConfiguration);
+  SerialCommunicationManager(std::unique_ptr<EncodingManager> encodingManager, VRSerialConfiguration configuration, const VRDeviceConfiguration& deviceConfiguration);
 
   bool IsConnected();
 

--- a/include/Communication/SerialCommunicationManager.h
+++ b/include/Communication/SerialCommunicationManager.h
@@ -12,26 +12,25 @@
 
 class SerialCommunicationManager : public CommunicationManager {
  public:
-  SerialCommunicationManager(std::unique_ptr<EncodingManager> encodingManager, const VRSerialConfiguration_t& configuration);
+  SerialCommunicationManager(
+	  std::unique_ptr<EncodingManager> encodingManager,
+	  VRSerialConfiguration_t configuration,
+	  const VRDeviceConfiguration_t& deviceConfiguration);
 
- public:
-  bool IsConnected();
+  bool IsConnected() override;
 
  protected:
-  bool Connect();
-  bool DisconnectFromDevice();
-  void LogError(const char* message);
-  void LogMessage(const char* message);
-  bool ReceiveNextPacket(std::string& buff);
-  bool SendMessageToDevice();
+  bool Connect() override;
+  bool DisconnectFromDevice() override;
+  void LogError(const char* message) override;
+  void LogMessage(const char* message) override;
+  bool ReceiveNextPacket(std::string& buff) override;
+  bool SendMessageToDevice() override;
 
  private:
   bool PurgeBuffer();
 
- private:
   VRSerialConfiguration_t m_serialConfiguration;
-
   std::atomic<bool> m_isConnected;
-
   std::atomic<HANDLE> m_hSerial;
 };

--- a/include/DeviceConfiguration.h
+++ b/include/DeviceConfiguration.h
@@ -32,42 +32,31 @@ struct VRSerialConfiguration_t {
   std::string port;
   int baudRate;
 
-  VRSerialConfiguration_t(const std::string port, const int baudRate)
-    : port(port),
-      baudRate(baudRate) {
-  }
+  VRSerialConfiguration_t(const std::string port, const int baudRate) : port(port), baudRate(baudRate) {}
 };
 
 struct VRBTSerialConfiguration_t {
   std::string name;
 
-  VRBTSerialConfiguration_t(const std::string name)
-    : name(name) {
-  }
+  VRBTSerialConfiguration_t(const std::string name) : name(name) {}
 };
 
 struct VRPoseConfiguration_t {
   vr::HmdVector3_t offsetVector;
   vr::HmdQuaternion_t angleOffsetQuaternion;
   float poseTimeOffset;
-  bool controllerOverrideEnabled;
   int controllerIdOverride;
+  bool controllerOverrideEnabled;
   bool calibrationButtonEnabled;
 
-  VRPoseConfiguration_t(
-      const vr::HmdVector3_t offsetVector,
-      const vr::HmdQuaternion_t angleOffsetQuaternion,
-      const float poseTimeOffset,
-      const bool controllerOverrideEnabled,
-      const int controllerIdOverride,
-      const bool calibrationButtonEnabled)
-    : offsetVector(offsetVector),
-      angleOffsetQuaternion(angleOffsetQuaternion),
-      poseTimeOffset(poseTimeOffset),
-      controllerOverrideEnabled(controllerOverrideEnabled),
-      controllerIdOverride(controllerIdOverride),
-      calibrationButtonEnabled(calibrationButtonEnabled) {
-  }
+  VRPoseConfiguration_t(const vr::HmdVector3_t offsetVector, const vr::HmdQuaternion_t angleOffsetQuaternion, const float poseTimeOffset,
+                        const bool controllerOverrideEnabled, const int controllerIdOverride, const bool calibrationButtonEnabled)
+      : offsetVector(offsetVector),
+        angleOffsetQuaternion(angleOffsetQuaternion),
+        poseTimeOffset(poseTimeOffset),
+        controllerIdOverride(controllerIdOverride),
+        controllerOverrideEnabled(controllerOverrideEnabled),
+        calibrationButtonEnabled(calibrationButtonEnabled) {}
 };
 
 struct VRDeviceConfiguration_t {
@@ -79,20 +68,13 @@ struct VRDeviceConfiguration_t {
   VRCommunicationProtocol communicationProtocol;
   VRDeviceDriver deviceDriver;
 
-  VRDeviceConfiguration_t(
-      const vr::ETrackedControllerRole role,
-      const bool enabled,
-      const bool feedbackEnabled,
-      const VRPoseConfiguration_t poseConfiguration,
-      const VREncodingProtocol encodingProtocol,
-      const VRCommunicationProtocol communicationProtocol,
-      const VRDeviceDriver deviceDriver)
-    : role(role),
-      enabled(enabled),
-      feedbackEnabled(feedbackEnabled),
-      poseConfiguration(poseConfiguration),
-      encodingProtocol(encodingProtocol),
-      communicationProtocol(communicationProtocol),
-      deviceDriver(deviceDriver) {
-  }
+  VRDeviceConfiguration_t(const vr::ETrackedControllerRole role, const bool enabled, const bool feedbackEnabled, const VRPoseConfiguration_t poseConfiguration,
+                          const VREncodingProtocol encodingProtocol, const VRCommunicationProtocol communicationProtocol, const VRDeviceDriver deviceDriver)
+      : role(role),
+        enabled(enabled),
+        feedbackEnabled(feedbackEnabled),
+        poseConfiguration(poseConfiguration),
+        encodingProtocol(encodingProtocol),
+        communicationProtocol(communicationProtocol),
+        deviceDriver(deviceDriver) {}
 };

--- a/include/DeviceConfiguration.h
+++ b/include/DeviceConfiguration.h
@@ -32,48 +32,67 @@ struct VRSerialConfiguration_t {
   std::string port;
   int baudRate;
 
-  VRSerialConfiguration_t(std::string port, int baudRate) : port(port), baudRate(baudRate){};
+  VRSerialConfiguration_t(const std::string port, const int baudRate)
+    : port(port),
+      baudRate(baudRate) {
+  }
 };
 
 struct VRBTSerialConfiguration_t {
   std::string name;
 
-  VRBTSerialConfiguration_t(std::string name) : name(name){};
+  VRBTSerialConfiguration_t(const std::string name)
+    : name(name) {
+  }
 };
 
 struct VRPoseConfiguration_t {
-  VRPoseConfiguration_t(vr::HmdVector3_t offsetVector, vr::HmdQuaternion_t angleOffsetQuaternion, float poseTimeOffset, bool controllerOverrideEnabled,
-                        int controllerIdOverride, bool calibrationButtonEnabled)
-      : offsetVector(offsetVector),
-        angleOffsetQuaternion(angleOffsetQuaternion),
-        poseTimeOffset(poseTimeOffset),
-        controllerOverrideEnabled(controllerOverrideEnabled),
-        controllerIdOverride(controllerIdOverride),
-        calibrationButtonEnabled(calibrationButtonEnabled){};
   vr::HmdVector3_t offsetVector;
   vr::HmdQuaternion_t angleOffsetQuaternion;
   float poseTimeOffset;
-  int controllerIdOverride;
   bool controllerOverrideEnabled;
+  int controllerIdOverride;
   bool calibrationButtonEnabled;
+
+  VRPoseConfiguration_t(
+      const vr::HmdVector3_t offsetVector,
+      const vr::HmdQuaternion_t angleOffsetQuaternion,
+      const float poseTimeOffset,
+      const bool controllerOverrideEnabled,
+      const int controllerIdOverride,
+      const bool calibrationButtonEnabled)
+    : offsetVector(offsetVector),
+      angleOffsetQuaternion(angleOffsetQuaternion),
+      poseTimeOffset(poseTimeOffset),
+      controllerOverrideEnabled(controllerOverrideEnabled),
+      controllerIdOverride(controllerIdOverride),
+      calibrationButtonEnabled(calibrationButtonEnabled) {
+  }
 };
 
 struct VRDeviceConfiguration_t {
-  VRDeviceConfiguration_t(vr::ETrackedControllerRole role, bool enabled, VRPoseConfiguration_t poseConfiguration, VREncodingProtocol encodingProtocol,
-                          VRCommunicationProtocol communicationProtocol, VRDeviceDriver deviceDriver)
-      : role(role),
-        enabled(enabled),
-        poseConfiguration(poseConfiguration),
-        encodingProtocol(encodingProtocol),
-        communicationProtocol(communicationProtocol),
-        deviceDriver(deviceDriver){};
-
   vr::ETrackedControllerRole role;
   bool enabled;
-
+  bool feedbackEnabled;
   VRPoseConfiguration_t poseConfiguration;
-
   VREncodingProtocol encodingProtocol;
   VRCommunicationProtocol communicationProtocol;
   VRDeviceDriver deviceDriver;
+
+  VRDeviceConfiguration_t(
+      const vr::ETrackedControllerRole role,
+      const bool enabled,
+      const bool feedbackEnabled,
+      const VRPoseConfiguration_t poseConfiguration,
+      const VREncodingProtocol encodingProtocol,
+      const VRCommunicationProtocol communicationProtocol,
+      const VRDeviceDriver deviceDriver)
+    : role(role),
+      enabled(enabled),
+      feedbackEnabled(feedbackEnabled),
+      poseConfiguration(poseConfiguration),
+      encodingProtocol(encodingProtocol),
+      communicationProtocol(communicationProtocol),
+      deviceDriver(deviceDriver) {
+  }
 };

--- a/include/DeviceConfiguration.h
+++ b/include/DeviceConfiguration.h
@@ -33,13 +33,19 @@ struct VRSerialConfiguration {
   std::string port;
   int baudRate;
 
-  VRSerialConfiguration(const std::string port, const int baudRate) : port(port), baudRate(baudRate) {}
+  VRSerialConfiguration(std::string port, int baudRate) : port(port), baudRate(baudRate){};
 };
 
 struct VRBTSerialConfiguration {
   std::string name;
 
-  VRBTSerialConfiguration(const std::string name) : name(name) {}
+  VRBTSerialConfiguration(std::string name) : name(name){};
+};
+
+struct VRNamedPipeInputConfiguration {
+  std::string pipeName;
+
+  VRNamedPipeInputConfiguration(std::string pipeName) : pipeName(pipeName){};
 };
 
 struct VRPoseConfiguration {
@@ -50,7 +56,7 @@ struct VRPoseConfiguration {
   bool controllerOverrideEnabled;
   bool calibrationButtonEnabled;
 
-  VRPoseConfiguration_t(const vr::HmdVector3_t offsetVector, const vr::HmdQuaternion_t angleOffsetQuaternion, const float poseTimeOffset,
+  VRPoseConfiguration(const vr::HmdVector3_t offsetVector, const vr::HmdQuaternion_t angleOffsetQuaternion, const float poseTimeOffset,
                         const bool controllerOverrideEnabled, const int controllerIdOverride, const bool calibrationButtonEnabled)
       : offsetVector(offsetVector),
         angleOffsetQuaternion(angleOffsetQuaternion),
@@ -69,7 +75,7 @@ struct VRDeviceConfiguration {
   VRCommunicationProtocol communicationProtocol;
   VRDeviceDriver deviceDriver;
 
-  VRDeviceConfiguration_t(const vr::ETrackedControllerRole role, const bool enabled, const bool feedbackEnabled, const VRPoseConfiguration poseConfiguration,
+  VRDeviceConfiguration(const vr::ETrackedControllerRole role, const bool enabled, const bool feedbackEnabled, const VRPoseConfiguration poseConfiguration,
                           const VREncodingProtocol encodingProtocol, const VRCommunicationProtocol communicationProtocol, const VRDeviceDriver deviceDriver)
       : role(role),
         enabled(enabled),

--- a/include/DeviceDriver/KnuckleDriver.h
+++ b/include/DeviceDriver/KnuckleDriver.h
@@ -7,7 +7,6 @@
 
 #include "Bones.h"
 #include "Communication/CommunicationManager.h"
-#include "ControllerPose.h"
 #include "DeviceConfiguration.h"
 #include "DeviceDriver/DeviceDriver.h"
 #include "Encode/EncodingManager.h"
@@ -41,16 +40,19 @@ enum class KnuckleDeviceComponentIndex : int {
 };
 
 class KnuckleDeviceDriver : public DeviceDriver {
- public:
-  KnuckleDeviceDriver(std::unique_ptr<CommunicationManager> communicationManager, std::shared_ptr<BoneAnimator> boneAnimator, std::string serialNumber,
-                      VRDeviceConfiguration_t configuration);
+public:
+  KnuckleDeviceDriver(
+      std::unique_ptr<CommunicationManager> communicationManager,
+      std::shared_ptr<BoneAnimator> boneAnimator,
+      std::string serialNumber,
+      VRDeviceConfiguration_t configuration);
 
-  void HandleInput(VRInputData_t datas);
-  void SetupProps(vr::PropertyContainerHandle_t& props);
-  void StartingDevice();
-  void StoppingDevice();
+  void HandleInput(VRInputData_t datas) override;
+  void SetupProps(vr::PropertyContainerHandle_t& props) override;
+  void StartingDevice() override;
+  void StoppingDevice() override;
 
- private:
+private:
   vr::VRInputComponentHandle_t m_inputComponentHandles[(int)KnuckleDeviceComponentIndex::Count];
   vr::VRInputComponentHandle_t m_haptic;
   std::unique_ptr<FFBListener> m_ffbProvider;

--- a/include/DeviceDriver/KnuckleDriver.h
+++ b/include/DeviceDriver/KnuckleDriver.h
@@ -7,6 +7,7 @@
 
 #include "Bones.h"
 #include "Communication/CommunicationManager.h"
+#include "ControllerPose.h"
 #include "DeviceConfiguration.h"
 #include "DeviceDriver/DeviceDriver.h"
 #include "Encode/EncodingManager.h"
@@ -40,19 +41,16 @@ enum class KnuckleDeviceComponentIndex : int {
 };
 
 class KnuckleDeviceDriver : public DeviceDriver {
-public:
-  KnuckleDeviceDriver(
-      std::unique_ptr<CommunicationManager> communicationManager,
-      std::shared_ptr<BoneAnimator> boneAnimator,
-      std::string serialNumber,
-      VRDeviceConfiguration_t configuration);
+ public:
+  KnuckleDeviceDriver(std::unique_ptr<CommunicationManager> communicationManager, std::shared_ptr<BoneAnimator> boneAnimator, std::string serialNumber,
+                      VRDeviceConfiguration_t configuration);
 
-  void HandleInput(VRInputData_t datas) override;
-  void SetupProps(vr::PropertyContainerHandle_t& props) override;
-  void StartingDevice() override;
-  void StoppingDevice() override;
+  void HandleInput(VRInputData_t datas);
+  void SetupProps(vr::PropertyContainerHandle_t& props);
+  void StartingDevice();
+  void StoppingDevice();
 
-private:
+ private:
   vr::VRInputComponentHandle_t m_inputComponentHandles[(int)KnuckleDeviceComponentIndex::Count];
   vr::VRInputComponentHandle_t m_haptic;
   std::unique_ptr<FFBListener> m_ffbProvider;

--- a/openglove/resources/settings/default.vrsettings
+++ b/openglove/resources/settings/default.vrsettings
@@ -1,9 +1,9 @@
 {
-  "driver_openglove":
-  {
+  "driver_openglove": {
     "__title": "OpenGlove Configuration",
     "left_enabled": true,
     "right_enabled": true,
+    "feedback_enabled": true,
     "communication_protocol": 0, //title:Communication Method
     "device_driver": 1, //title:Device Driver Emulation
     "encoding_protocol": 1 //title:Encoding Protocol

--- a/src/Communication/BTSerialCommunicationManager.cpp
+++ b/src/Communication/BTSerialCommunicationManager.cpp
@@ -97,8 +97,8 @@ bool BTSerialCommunicationManager::ConnectToDevice(BTH_ADDR& deviceBtAddress) {
   }
 
   unsigned long nonBlockingMode = 1;
-  if (ioctlsocket(m_btClientSocket, FIONBIO, &nonBlockingMode) != 0) // set the socket to be non-blocking, meaning
-                                                                           // it will return right away when sending/receiving
+  // set the socket to be non-blocking, meaning it will return right away when sending/receiving
+  if (ioctlsocket(m_btClientSocket, FIONBIO, &nonBlockingMode) != 0)
   {
     LogError("Could not set socket to be non-blocking");
     return false;

--- a/src/Communication/BTSerialCommunicationManager.cpp
+++ b/src/Communication/BTSerialCommunicationManager.cpp
@@ -9,19 +9,11 @@
 #include "Util/Logic.h"
 #include "Util/Windows.h"
 
-BTSerialCommunicationManager::BTSerialCommunicationManager(
-    std::unique_ptr<EncodingManager> encodingManager,
-    VRBTSerialConfiguration_t configuration,
-    const VRDeviceConfiguration_t& deviceConfiguration)
-  : CommunicationManager(std::move(encodingManager), deviceConfiguration),
-    m_btSerialConfiguration(std::move(configuration)),
-    m_isConnected(false),
-    m_btClientSocket(NULL) {
-}
+BTSerialCommunicationManager::BTSerialCommunicationManager(std::unique_ptr<EncodingManager> encodingManager, VRBTSerialConfiguration_t configuration,
+                                                           const VRDeviceConfiguration_t& deviceConfiguration)
+    : CommunicationManager(std::move(encodingManager), deviceConfiguration), m_btSerialConfiguration(configuration), m_isConnected(false), m_btClientSocket(NULL) {}
 
-bool BTSerialCommunicationManager::IsConnected() {
-  return m_isConnected;
-}
+bool BTSerialCommunicationManager::IsConnected() { return m_isConnected; }
 
 bool BTSerialCommunicationManager::Connect() {
   // We're not yet connected
@@ -69,9 +61,7 @@ bool BTSerialCommunicationManager::SendMessageToDevice() {
 
   const char* message = m_writeString.c_str();
 
-  if (!retry([&]() {
-    return send(m_btClientSocket, message, (int)m_writeString.length(), 0) != SOCKET_ERROR;
-  }, 5, 10)) {
+  if (!retry([&]() { return send(m_btClientSocket, message, (int)m_writeString.length(), 0) != SOCKET_ERROR; }, 5, 10)) {
     LogError("Sending to Bluetooth Device failed... closing");
 
     closesocket(m_btClientSocket);
@@ -82,15 +72,15 @@ bool BTSerialCommunicationManager::SendMessageToDevice() {
 }
 
 bool BTSerialCommunicationManager::ConnectToDevice(BTH_ADDR& deviceBtAddress) {
-  m_btClientSocket = socket(AF_BTH, SOCK_STREAM, BTHPROTO_RFCOMM); // initialize BT windows socket
+  m_btClientSocket = socket(AF_BTH, SOCK_STREAM, BTHPROTO_RFCOMM);  // initialize BT windows socket
 
   SOCKADDR_BTH m_btSocketAddress{};
   m_btSocketAddress.addressFamily = AF_BTH;
   m_btSocketAddress.serviceClassId = RFCOMM_PROTOCOL_UUID;
-  m_btSocketAddress.port = 0;                 // port needs to be 0 if the remote device is a client. See references.
-  m_btSocketAddress.btAddr = deviceBtAddress; // this is the BT address of the remote device.
+  m_btSocketAddress.port = 0;                  // port needs to be 0 if the remote device is a client. See references.
+  m_btSocketAddress.btAddr = deviceBtAddress;  // this is the BT address of the remote device.
 
-  if (connect(m_btClientSocket, (SOCKADDR*)&m_btSocketAddress, sizeof(m_btSocketAddress)) != 0) // connect to the BT device.
+  if (connect(m_btClientSocket, (SOCKADDR*)&m_btSocketAddress, sizeof(m_btSocketAddress)) != 0)  // connect to the BT device.
   {
     LogError("Could not connect socket to Bluetooth Device");
     return false;
@@ -98,8 +88,7 @@ bool BTSerialCommunicationManager::ConnectToDevice(BTH_ADDR& deviceBtAddress) {
 
   unsigned long nonBlockingMode = 1;
   // set the socket to be non-blocking, meaning it will return right away when sending/receiving
-  if (ioctlsocket(m_btClientSocket, FIONBIO, &nonBlockingMode) != 0)
-  {
+  if (ioctlsocket(m_btClientSocket, FIONBIO, &nonBlockingMode) != 0) {
     LogError("Could not set socket to be non-blocking");
     return false;
   }
@@ -109,18 +98,18 @@ bool BTSerialCommunicationManager::ConnectToDevice(BTH_ADDR& deviceBtAddress) {
 
 bool BTSerialCommunicationManager::GetPairedDeviceBtAddress(BTH_ADDR* deviceBtAddress) {
   BLUETOOTH_DEVICE_SEARCH_PARAMS btDeviceSearchParameters = {
-      sizeof(BLUETOOTH_DEVICE_SEARCH_PARAMS), // size of object
-      1,                                      // return authenticated devices
-      0,                                      // return remembered devices
-      1,                                      // return unknown devices
-      1,                                      // return connected devices
-      1,                                      // issue inquery
-      2,                                      // timeout multipler. Multiply this value by 1.28 seconds to get timeout.
-      NULL                                    // radio handler
+      sizeof(BLUETOOTH_DEVICE_SEARCH_PARAMS),  // size of object
+      1,                                       // return authenticated devices
+      0,                                       // return remembered devices
+      1,                                       // return unknown devices
+      1,                                       // return connected devices
+      1,                                       // issue inquery
+      2,                                       // timeout multipler. Multiply this value by 1.28 seconds to get timeout.
+      NULL                                     // radio handler
   };
-  BLUETOOTH_DEVICE_INFO btDeviceInfo = {sizeof(BLUETOOTH_DEVICE_INFO), 0}; // default
+  BLUETOOTH_DEVICE_INFO btDeviceInfo = {sizeof(BLUETOOTH_DEVICE_INFO), 0};  // default
   HBLUETOOTH_DEVICE_FIND btDevice = NULL;
-  btDevice = BluetoothFindFirstDevice(&btDeviceSearchParameters, &btDeviceInfo); // returns first BT device connected to this machine
+  btDevice = BluetoothFindFirstDevice(&btDeviceSearchParameters, &btDeviceInfo);  // returns first BT device connected to this machine
   if (btDevice == NULL) {
     LogMessage("Could not find any bluetooth devices");
     *deviceBtAddress = NULL;
@@ -133,7 +122,7 @@ bool BTSerialCommunicationManager::GetPairedDeviceBtAddress(BTH_ADDR* deviceBtAd
   do {
     if (wcscmp(btDeviceInfo.szName, wcDeviceName) == 0) {
       LogMessage("Bluetooth Device found");
-      if (btDeviceInfo.fAuthenticated) // I found that if fAuthenticated is true it means the device is paired.
+      if (btDeviceInfo.fAuthenticated)  // I found that if fAuthenticated is true it means the device is paired.
       {
         LogMessage("Bluetooth Device is authenticated");
         *deviceBtAddress = btDeviceInfo.Address.ullLong;
@@ -142,7 +131,7 @@ bool BTSerialCommunicationManager::GetPairedDeviceBtAddress(BTH_ADDR* deviceBtAd
         LogMessage("This Bluetooth Device is not authenticated. Please pair with it first");
       }
     }
-  } while (BluetoothFindNextDevice(btDevice, &btDeviceInfo)); // loop through remaining BT devices connected to this machine
+  } while (BluetoothFindNextDevice(btDevice, &btDeviceInfo));  // loop through remaining BT devices connected to this machine
 
   LogMessage("Could not find paired Bluetooth Device");
   *deviceBtAddress = NULL;
@@ -152,7 +141,7 @@ bool BTSerialCommunicationManager::GetPairedDeviceBtAddress(BTH_ADDR* deviceBtAd
 bool BTSerialCommunicationManager::StartupWindowsSocket() {
   WORD wVersionRequested = MAKEWORD(2, 2);
   WSADATA wsaData;
-  int wsaStartupError = WSAStartup(wVersionRequested, &wsaData); // call this before using BT windows socket.
+  int wsaStartupError = WSAStartup(wVersionRequested, &wsaData);  // call this before using BT windows socket.
   if (wsaStartupError != 0) {
     LogMessage("WSA failed to startup");
     return false;

--- a/src/Communication/BTSerialCommunicationManager.cpp
+++ b/src/Communication/BTSerialCommunicationManager.cpp
@@ -98,8 +98,8 @@ bool BTSerialCommunicationManager::ConnectToDevice(BTH_ADDR& deviceBtAddress) {
 
   unsigned long nonBlockingMode = 1;
   if (ioctlsocket(m_btClientSocket, FIONBIO, &nonBlockingMode) != 0) // set the socket to be non-blocking, meaning
+                                                                           // it will return right away when sending/receiving
   {
-    // it will return right away when sending/recieving
     LogError("Could not set socket to be non-blocking");
     return false;
   }

--- a/src/Communication/BTSerialCommunicationManager.cpp
+++ b/src/Communication/BTSerialCommunicationManager.cpp
@@ -1,16 +1,27 @@
 #include "Communication/BTSerialCommunicationManager.h"
 
 #include <Windows.h>
-#include <Ws2bth.h>
+#include <ws2bth.h>
+
+#include <utility>
 
 #include "DriverLog.h"
 #include "Util/Logic.h"
 #include "Util/Windows.h"
 
-BTSerialCommunicationManager::BTSerialCommunicationManager(std::unique_ptr<EncodingManager> encodingManager, const VRBTSerialConfiguration_t& configuration)
-    : CommunicationManager(std::move(encodingManager)), m_btSerialConfiguration(configuration), m_isConnected(false), m_btClientSocket(NULL) {}
+BTSerialCommunicationManager::BTSerialCommunicationManager(
+    std::unique_ptr<EncodingManager> encodingManager,
+    VRBTSerialConfiguration_t configuration,
+    const VRDeviceConfiguration_t& deviceConfiguration)
+  : CommunicationManager(std::move(encodingManager), deviceConfiguration),
+    m_btSerialConfiguration(std::move(configuration)),
+    m_isConnected(false),
+    m_btClientSocket(NULL) {
+}
 
-bool BTSerialCommunicationManager::IsConnected() { return m_isConnected; }
+bool BTSerialCommunicationManager::IsConnected() {
+  return m_isConnected;
+}
 
 bool BTSerialCommunicationManager::Connect() {
   // We're not yet connected
@@ -58,7 +69,9 @@ bool BTSerialCommunicationManager::SendMessageToDevice() {
 
   const char* message = m_writeString.c_str();
 
-  if (!retry([&]() { return send(m_btClientSocket, message, (int)m_writeString.length(), 0) != SOCKET_ERROR; }, 5, 10)) {
+  if (!retry([&]() {
+    return send(m_btClientSocket, message, (int)m_writeString.length(), 0) != SOCKET_ERROR;
+  }, 5, 10)) {
     LogError("Sending to Bluetooth Device failed... closing");
 
     closesocket(m_btClientSocket);
@@ -69,23 +82,24 @@ bool BTSerialCommunicationManager::SendMessageToDevice() {
 }
 
 bool BTSerialCommunicationManager::ConnectToDevice(BTH_ADDR& deviceBtAddress) {
-  m_btClientSocket = socket(AF_BTH, SOCK_STREAM, BTHPROTO_RFCOMM);  // initialize BT windows socket
+  m_btClientSocket = socket(AF_BTH, SOCK_STREAM, BTHPROTO_RFCOMM); // initialize BT windows socket
 
   SOCKADDR_BTH m_btSocketAddress{};
   m_btSocketAddress.addressFamily = AF_BTH;
   m_btSocketAddress.serviceClassId = RFCOMM_PROTOCOL_UUID;
-  m_btSocketAddress.port = 0;                  // port needs to be 0 if the remote device is a client. See references.
-  m_btSocketAddress.btAddr = deviceBtAddress;  // this is the BT address of the remote device.
+  m_btSocketAddress.port = 0;                 // port needs to be 0 if the remote device is a client. See references.
+  m_btSocketAddress.btAddr = deviceBtAddress; // this is the BT address of the remote device.
 
-  if (connect(m_btClientSocket, (SOCKADDR*)&m_btSocketAddress, sizeof(m_btSocketAddress)) != 0)  // connect to the BT device.
+  if (connect(m_btClientSocket, (SOCKADDR*)&m_btSocketAddress, sizeof(m_btSocketAddress)) != 0) // connect to the BT device.
   {
     LogError("Could not connect socket to Bluetooth Device");
     return false;
   }
 
   unsigned long nonBlockingMode = 1;
-  if (ioctlsocket(m_btClientSocket, FIONBIO, &nonBlockingMode) != 0)  // set the socket to be non-blocking, meaning
-  {                                                                   // it will return right away when sending/recieving
+  if (ioctlsocket(m_btClientSocket, FIONBIO, &nonBlockingMode) != 0) // set the socket to be non-blocking, meaning
+  {
+    // it will return right away when sending/recieving
     LogError("Could not set socket to be non-blocking");
     return false;
   }
@@ -95,18 +109,18 @@ bool BTSerialCommunicationManager::ConnectToDevice(BTH_ADDR& deviceBtAddress) {
 
 bool BTSerialCommunicationManager::GetPairedDeviceBtAddress(BTH_ADDR* deviceBtAddress) {
   BLUETOOTH_DEVICE_SEARCH_PARAMS btDeviceSearchParameters = {
-      sizeof(BLUETOOTH_DEVICE_SEARCH_PARAMS),  // size of object
-      1,                                       // return authenticated devices
-      0,                                       // return remembered devices
-      1,                                       // return unknown devices
-      1,                                       // return connected devices
-      1,                                       // issue inquery
-      2,                                       // timeout multipler. Multiply this value by 1.28 seconds to get timeout.
-      NULL                                     // radio handler
+      sizeof(BLUETOOTH_DEVICE_SEARCH_PARAMS), // size of object
+      1,                                      // return authenticated devices
+      0,                                      // return remembered devices
+      1,                                      // return unknown devices
+      1,                                      // return connected devices
+      1,                                      // issue inquery
+      2,                                      // timeout multipler. Multiply this value by 1.28 seconds to get timeout.
+      NULL                                    // radio handler
   };
-  BLUETOOTH_DEVICE_INFO btDeviceInfo = {sizeof(BLUETOOTH_DEVICE_INFO), 0};  // default
+  BLUETOOTH_DEVICE_INFO btDeviceInfo = {sizeof(BLUETOOTH_DEVICE_INFO), 0}; // default
   HBLUETOOTH_DEVICE_FIND btDevice = NULL;
-  btDevice = BluetoothFindFirstDevice(&btDeviceSearchParameters, &btDeviceInfo);  // returns first BT device connected to this machine
+  btDevice = BluetoothFindFirstDevice(&btDeviceSearchParameters, &btDeviceInfo); // returns first BT device connected to this machine
   if (btDevice == NULL) {
     LogMessage("Could not find any bluetooth devices");
     *deviceBtAddress = NULL;
@@ -119,7 +133,7 @@ bool BTSerialCommunicationManager::GetPairedDeviceBtAddress(BTH_ADDR* deviceBtAd
   do {
     if (wcscmp(btDeviceInfo.szName, wcDeviceName) == 0) {
       LogMessage("Bluetooth Device found");
-      if (btDeviceInfo.fAuthenticated)  // I found that if fAuthenticated is true it means the device is paired.
+      if (btDeviceInfo.fAuthenticated) // I found that if fAuthenticated is true it means the device is paired.
       {
         LogMessage("Bluetooth Device is authenticated");
         *deviceBtAddress = btDeviceInfo.Address.ullLong;
@@ -128,7 +142,7 @@ bool BTSerialCommunicationManager::GetPairedDeviceBtAddress(BTH_ADDR* deviceBtAd
         LogMessage("This Bluetooth Device is not authenticated. Please pair with it first");
       }
     }
-  } while (BluetoothFindNextDevice(btDevice, &btDeviceInfo));  // loop through remaining BT devices connected to this machine
+  } while (BluetoothFindNextDevice(btDevice, &btDeviceInfo)); // loop through remaining BT devices connected to this machine
 
   LogMessage("Could not find paired Bluetooth Device");
   *deviceBtAddress = NULL;
@@ -138,7 +152,7 @@ bool BTSerialCommunicationManager::GetPairedDeviceBtAddress(BTH_ADDR* deviceBtAd
 bool BTSerialCommunicationManager::StartupWindowsSocket() {
   WORD wVersionRequested = MAKEWORD(2, 2);
   WSADATA wsaData;
-  int wsaStartupError = WSAStartup(wVersionRequested, &wsaData);  // call this before using BT windows socket.
+  int wsaStartupError = WSAStartup(wVersionRequested, &wsaData); // call this before using BT windows socket.
   if (wsaStartupError != 0) {
     LogMessage("WSA failed to startup");
     return false;

--- a/src/Communication/CommunicationManager.cpp
+++ b/src/Communication/CommunicationManager.cpp
@@ -6,7 +6,9 @@
 
 static const uint32_t c_listenerWaitTime = 1000;
 
-CommunicationManager::CommunicationManager(std::unique_ptr<EncodingManager> encodingManager, const VRDeviceConfiguration_t& deviceConfiguration)
+CommunicationManager::CommunicationManager(const VRDeviceConfiguration& deviceConfiguration) : CommunicationManager(nullptr, deviceConfiguration) {}
+
+CommunicationManager::CommunicationManager(std::unique_ptr<EncodingManager> encodingManager, const VRDeviceConfiguration& deviceConfiguration)
     : m_encodingManager(std::move(encodingManager)), m_deviceConfiguration(deviceConfiguration), m_threadActive(false), m_writeString() {
   // initially no force feedback
   QueueSend(VRFFBData(0, 0, 0, 0, 0));

--- a/src/Communication/NamedPipeCommunicationManager.cpp
+++ b/src/Communication/NamedPipeCommunicationManager.cpp
@@ -1,6 +1,7 @@
 #include "Communication/NamedPipeCommunicationManager.h"
 
-NamedPipeCommunicationManager::NamedPipeCommunicationManager(const VRNamedPipeInputConfiguration& configuration) : m_configuration(configuration), m_isConnected(false){};
+NamedPipeCommunicationManager::NamedPipeCommunicationManager(const VRNamedPipeInputConfiguration& configuration, const VRDeviceConfiguration& deviceConfiguration)
+    : CommunicationManager(deviceConfiguration), m_configuration(configuration), m_isConnected(false){};
 
 bool NamedPipeCommunicationManager::Connect() {
   m_namedPipeListener = std::make_unique<NamedPipeListener<VRInputData>>(m_configuration.pipeName);

--- a/src/Communication/SerialCommunicationManager.cpp
+++ b/src/Communication/SerialCommunicationManager.cpp
@@ -1,23 +1,15 @@
-#include <utility>
-
 #include "Communication/SerialCommunicationManager.h"
+
+#include <utility>
 
 #include "DriverLog.h"
 #include "Util/Windows.h"
 
-SerialCommunicationManager::SerialCommunicationManager(
-    std::unique_ptr<EncodingManager> encodingManager,
-    VRSerialConfiguration_t configuration,
-    const VRDeviceConfiguration_t& deviceConfiguration)
-  : CommunicationManager(std::move(encodingManager), deviceConfiguration),
-    m_serialConfiguration(std::move(configuration)),
-    m_isConnected(false),
-    m_hSerial(nullptr) {
-}
+SerialCommunicationManager::SerialCommunicationManager(std::unique_ptr<EncodingManager> encodingManager, VRSerialConfiguration_t configuration,
+                                                       const VRDeviceConfiguration_t& deviceConfiguration)
+    : CommunicationManager(std::move(encodingManager), deviceConfiguration), m_serialConfiguration(std::move(configuration)), m_isConnected(false), m_hSerial(nullptr) {}
 
-bool SerialCommunicationManager::IsConnected() {
-  return m_isConnected;
-};
+bool SerialCommunicationManager::IsConnected() { return m_isConnected; };
 
 bool SerialCommunicationManager::Connect() {
   // We're not yet connected
@@ -42,7 +34,7 @@ bool SerialCommunicationManager::Connect() {
   dcbSerialParams.ByteSize = 8;
   dcbSerialParams.StopBits = ONESTOPBIT;
   dcbSerialParams.Parity = NOPARITY;
-  dcbSerialParams.fDtrControl = DTR_CONTROL_ENABLE; // reset upon establishing a connection
+  dcbSerialParams.fDtrControl = DTR_CONTROL_ENABLE;  // reset upon establishing a connection
 
   // set the parameters and check for their proper application
   if (!SetCommState(m_hSerial, &dcbSerialParams)) {
@@ -129,6 +121,4 @@ bool SerialCommunicationManager::SendMessageToDevice() {
   return true;
 }
 
-bool SerialCommunicationManager::PurgeBuffer() {
-  return PurgeComm(m_hSerial, PURGE_RXCLEAR | PURGE_TXCLEAR);
-}
+bool SerialCommunicationManager::PurgeBuffer() { return PurgeComm(m_hSerial, PURGE_RXCLEAR | PURGE_TXCLEAR); }

--- a/src/DeviceDriver/KnuckleDriver.cpp
+++ b/src/DeviceDriver/KnuckleDriver.cpp
@@ -2,19 +2,9 @@
 
 #include <utility>
 
-KnuckleDeviceDriver::KnuckleDeviceDriver(
-    std::unique_ptr<CommunicationManager> communicationManager,
-    std::shared_ptr<BoneAnimator> boneAnimator,
-    std::string serialNumber,
-    const VRDeviceConfiguration_t configuration)
-  : DeviceDriver(
-        std::move(communicationManager),
-        std::move(boneAnimator),
-        std::move(serialNumber),
-        configuration),
-    m_inputComponentHandles(),
-    m_haptic() {
-}
+KnuckleDeviceDriver::KnuckleDeviceDriver(std::unique_ptr<CommunicationManager> communicationManager, std::shared_ptr<BoneAnimator> boneAnimator, std::string serialNumber,
+                                         const VRDeviceConfiguration_t configuration)
+    : DeviceDriver(std::move(communicationManager), std::move(boneAnimator), std::move(serialNumber), configuration), m_inputComponentHandles(), m_haptic() {}
 
 void KnuckleDeviceDriver::HandleInput(VRInputData_t datas) {
   vr::VRDriverInput()->UpdateScalarComponent(m_inputComponentHandles[(int)KnuckleDeviceComponentIndex::THUMBSTICK_X], datas.joyX, 0);
@@ -52,7 +42,7 @@ void KnuckleDeviceDriver::SetupProps(vr::PropertyContainerHandle_t& props) {
   vr::VRProperties()->SetBoolProperty(props, vr::Prop_WillDriftInYaw_Bool, false);
   vr::VRProperties()->SetBoolProperty(props, vr::Prop_DeviceIsWireless_Bool, true);
   vr::VRProperties()->SetBoolProperty(props, vr::Prop_DeviceIsCharging_Bool, false);
-  vr::VRProperties()->SetFloatProperty(props, vr::Prop_DeviceBatteryPercentage_Float, 1.f); // Always charged
+  vr::VRProperties()->SetFloatProperty(props, vr::Prop_DeviceBatteryPercentage_Float, 1.f);  // Always charged
 
   vr::HmdMatrix34_t l_matrix = {-1.f, 0.f, 0.f, 0.f, 0.f, 0.f, -1.f, 0.f, 0.f, -1.f, 0.f, 0.f};
   vr::VRProperties()->SetProperty(props, vr::Prop_StatusDisplayTransform_Matrix34, &l_matrix, sizeof(vr::HmdMatrix34_t), vr::k_unHmdMatrix34PropertyTag);

--- a/src/DeviceProvider.cpp
+++ b/src/DeviceProvider.cpp
@@ -161,19 +161,9 @@ VRDeviceConfiguration_t DeviceProvider::GetDeviceConfiguration(vr::ETrackedContr
   const vr::HmdQuaternion_t angleOffsetQuaternion = EulerToQuaternion(DegToRad(offsetXRot), DegToRad(offsetYRot), DegToRad(offsetZRot));
 
   return VRDeviceConfiguration_t(
-    role,
-    isEnabled,
-    feedbackEnabled,
-    VRPoseConfiguration_t(
-      offsetVector,
-      angleOffsetQuaternion,
-      poseTimeOffset,
-      controllerOverrideEnabled,
-      controllerIdOverride,
-      calibrationButton),
-    encodingProtocol,
-    communicationProtocol,
-    deviceDriver);
+      role, isEnabled, feedbackEnabled,
+      VRPoseConfiguration_t(offsetVector, angleOffsetQuaternion, poseTimeOffset, controllerOverrideEnabled, controllerIdOverride, calibrationButton), encodingProtocol,
+      communicationProtocol, deviceDriver);
 }
 
 void DeviceProvider::Cleanup() {}

--- a/src/DeviceProvider.cpp
+++ b/src/DeviceProvider.cpp
@@ -77,7 +77,7 @@ std::unique_ptr<DeviceDriver> DeviceProvider::InstantiateDeviceDriver(VRDeviceCo
       DriverLog("Communication set to Named Pipe");
       std::string path = "\\\\.\\pipe\\vrapplication\\input\\" + std::string((isRightHand ? "right" : "left"));
       VRNamedPipeInputConfiguration namedPipeConfiguration(path);
-      communicationManager = std::make_unique<NamedPipeCommunicationManager>(namedPipeConfiguration);
+      communicationManager = std::make_unique<NamedPipeCommunicationManager>(namedPipeConfiguration, configuration);
       break;
     }
     case VRCommunicationProtocol::BT_SERIAL: {


### PR DESCRIPTION
Input throttling and configurable feedback

If the glove firmware sends data more often than we poll for it then the buffer will become saturated and block future reads. Data is guaranteed to be ready on the next read so just purge the buffers after we get a full set of encoded data.

Added config to enable/disable feedback for gloves that do not support it.