### PR TITLE
Fix controller discovery pipe

### DIFF
--- a/include/Util/NamedPipeListener.h
+++ b/include/Util/NamedPipeListener.h
@@ -184,8 +184,10 @@ void NamedPipeListener<T>::ListenerThread(const std::function<void(T*)>& callbac
       } else {
         if (GetLastError() == ERROR_IO_PENDING)
           listenerData.fPendingIO = true;
-        else
+        else {
+          LogError("Pipe received data but failed to read");
           DisconnectAndReconnect(&listenerData);
+        }
       }
     } else {  // Callback (see above)
       if (listenerData.dwBytesRead == sizeof(T)) {

--- a/overlay/main.h
+++ b/overlay/main.h
@@ -3,7 +3,7 @@
 #include <Windows.h>
 
 struct ControllerPipeData {
-  vr::TrackedDeviceIndex_t controllerId;
+  short controllerId;
 };
 
 class PipeHelper {


### PR DESCRIPTION
A recent change introduced an inconsistency with the named pipe struct members, causing reads to fail. This change reverts that back.