### PR TITLE
Thumb approximation for Index Emulation

### DIFF
--- a/include/DeviceDriver/KnuckleDriver.h
+++ b/include/DeviceDriver/KnuckleDriver.h
@@ -43,6 +43,7 @@ class KnuckleDeviceDriver : public DeviceDriver {
       std::unique_ptr<CommunicationManager> communicationManager,
       std::shared_ptr<BoneAnimator> boneAnimator,
       std::string serialNumber,
+      bool approximateThumb,
       VRDeviceConfiguration configuration);
 
   void HandleInput(VRInputData data) override;
@@ -54,4 +55,5 @@ class KnuckleDeviceDriver : public DeviceDriver {
   vr::VRInputComponentHandle_t inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::_Count)];
   vr::VRInputComponentHandle_t haptic_;
   std::unique_ptr<FFBListener> ffbProvider_;
+  bool approximateThumb_;
 };

--- a/openglove/resources/settings/default.vrsettings
+++ b/openglove/resources/settings/default.vrsettings
@@ -20,7 +20,8 @@
     "__title": "Knuckles Emulation",
     "__type": "device_driver:1",
     "left_serial_number": "LHR-E217CD00",
-    "right_serial_number": "LHR-E217CD01"
+    "right_serial_number": "LHR-E217CD01",
+	"approximate_thumb": true
   },
   "pose_settings":
   {

--- a/src/DeviceDriver/KnuckleDriver.cpp
+++ b/src/DeviceDriver/KnuckleDriver.cpp
@@ -13,7 +13,6 @@ KnuckleDeviceDriver::KnuckleDeviceDriver(
 
 void KnuckleDeviceDriver::HandleInput(const VRInputData data) {
   // clang-format off
-
   vr::VRDriverInput()->UpdateScalarComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::ThumbstickX)], data.joyX, 0);
   vr::VRDriverInput()->UpdateScalarComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::ThumbstickY)], data.joyY, 0);
 
@@ -23,8 +22,8 @@ void KnuckleDeviceDriver::HandleInput(const VRInputData data) {
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::TriggerClick)], data.trgButton, 0);
   vr::VRDriverInput()->UpdateScalarComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::TriggerValue)], data.flexion[1], 0);
 
-  vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::AClick)], data.aButton || data.flexion[0] < 0.5, 0); //Thumb approximation
-  vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::ATouch)], data.aButton, 0);
+  vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::AClick)], data.aButton, 0);
+  vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::ATouch)], data.aButton || data.flexion[0] < 0.5, 0); //Thumb approximation
 
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::BClick)], data.bButton, 0);
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::BTouch)], data.bButton, 0);

--- a/src/DeviceDriver/KnuckleDriver.cpp
+++ b/src/DeviceDriver/KnuckleDriver.cpp
@@ -6,10 +6,11 @@ KnuckleDeviceDriver::KnuckleDeviceDriver(
     std::unique_ptr<CommunicationManager> communicationManager,
     std::shared_ptr<BoneAnimator> boneAnimator,
     std::string serialNumber,
+    bool approximateThumb,
     const VRDeviceConfiguration configuration)
     : DeviceDriver(std::move(communicationManager), std::move(boneAnimator), std::move(serialNumber), configuration),
       inputComponentHandles_(),
-      haptic_() {}
+      haptic_(), approximateThumb_(approximateThumb){}
 
 void KnuckleDeviceDriver::HandleInput(const VRInputData data) {
   // clang-format off
@@ -23,7 +24,7 @@ void KnuckleDeviceDriver::HandleInput(const VRInputData data) {
   vr::VRDriverInput()->UpdateScalarComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::TriggerValue)], data.flexion[1], 0);
 
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::AClick)], data.aButton, 0);
-  vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::ATouch)], data.aButton || data.flexion[0] > 0.6, 0); //Thumb approximation
+  vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::ATouch)], data.aButton || (approximateThumb_ && data.flexion[0] > 0.6), 0); //Thumb approximation
 
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::BClick)], data.bButton, 0);
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::BTouch)], data.bButton, 0);

--- a/src/DeviceDriver/KnuckleDriver.cpp
+++ b/src/DeviceDriver/KnuckleDriver.cpp
@@ -13,6 +13,7 @@ KnuckleDeviceDriver::KnuckleDeviceDriver(
 
 void KnuckleDeviceDriver::HandleInput(const VRInputData data) {
   // clang-format off
+
   vr::VRDriverInput()->UpdateScalarComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::ThumbstickX)], data.joyX, 0);
   vr::VRDriverInput()->UpdateScalarComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::ThumbstickY)], data.joyY, 0);
 
@@ -22,7 +23,7 @@ void KnuckleDeviceDriver::HandleInput(const VRInputData data) {
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::TriggerClick)], data.trgButton, 0);
   vr::VRDriverInput()->UpdateScalarComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::TriggerValue)], data.flexion[1], 0);
 
-  vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::AClick)], data.aButton, 0);
+  vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::AClick)], data.aButton || data.flexion[0] < 0.5, 0); //Thumb approximation
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::ATouch)], data.aButton, 0);
 
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::BClick)], data.bButton, 0);

--- a/src/DeviceDriver/KnuckleDriver.cpp
+++ b/src/DeviceDriver/KnuckleDriver.cpp
@@ -23,7 +23,7 @@ void KnuckleDeviceDriver::HandleInput(const VRInputData data) {
   vr::VRDriverInput()->UpdateScalarComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::TriggerValue)], data.flexion[1], 0);
 
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::AClick)], data.aButton, 0);
-  vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::ATouch)], data.aButton || data.flexion[0] < 0.5, 0); //Thumb approximation
+  vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::ATouch)], data.aButton || data.flexion[0] > 0.6, 0); //Thumb approximation
 
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::BClick)], data.bButton, 0);
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::BTouch)], data.bButton, 0);

--- a/src/DeviceProvider.cpp
+++ b/src/DeviceProvider.cpp
@@ -107,9 +107,10 @@ std::unique_ptr<DeviceDriver> DeviceProvider::InstantiateDeviceDriver(
       char serialNumber[32];
       vr::VRSettings()->GetString(
           c_knuckleDeviceSettingsSection, isRightHand ? "right_serial_number" : "left_serial_number", serialNumber, sizeof serialNumber);
-
+      bool approximateThumb = vr::VRSettings()->GetBool(
+          c_knuckleDeviceSettingsSection, "approximate_thumb");
       return std::make_unique<KnuckleDeviceDriver>(
-          std::move(communicationManager), std::move(boneAnimator), serialNumber, configuration);
+          std::move(communicationManager), std::move(boneAnimator), serialNumber, approximateThumb, configuration);
     }
 
     default:


### PR DESCRIPTION
Allow some degree of thumb motion in index-emulated games, by setting (capacitive) touch on the A button when the thumb is pushed beyond a certain threshold.