### PR TITLE
Ensure encoding manager is valid before using

### DIFF
--- a/include/Communication/NamedPipeCommunicationManager.h
+++ b/include/Communication/NamedPipeCommunicationManager.h
@@ -11,6 +11,7 @@ class NamedPipeCommunicationManager : public CommunicationManager {
  public:
   NamedPipeCommunicationManager(VRNamedPipeInputConfiguration configuration, const VRDeviceConfiguration& deviceConfiguration);
   bool IsConnected() override;
+  void QueueSend(const VRFFBData& data) override{};
 
  protected:
   bool Connect() override;
@@ -25,7 +26,6 @@ class NamedPipeCommunicationManager : public CommunicationManager {
   bool ReceiveNextPacket(std::string& buff) override {
     return true;
   };
-  void QueueSend(const VRFFBData& data) override{};
 
   void BeginListener(const std::function<void(VRInputData)>& callback) override;
 

--- a/src/Communication/CommunicationManager.cpp
+++ b/src/Communication/CommunicationManager.cpp
@@ -28,7 +28,7 @@ void CommunicationManager::Disconnect() {
 void CommunicationManager::QueueSend(const VRFFBData& data) {
   std::lock_guard lock(writeMutex_);
 
-  writeString_ = encodingManager_->Encode(data);
+  if(encodingManager_ != nullptr) writeString_ = encodingManager_->Encode(data);
 }
 
 void CommunicationManager::ListenerThread(const std::function<void(VRInputData)>& callback) {


### PR DESCRIPTION
For some communications methods, there might not be an encoding manager. This causes problems when trying to send data, as it would use the encoding manager, which might be nullptr. This PR adds a check to make sure that isn't the case.