### PR TITLE
Refactor bones to interpolate between keyframes and have wider support for animation files

### DIFF
--- a/include/Bones.h
+++ b/include/Bones.h
@@ -57,6 +57,7 @@ struct AnimationData {
   float startTime;
   Transform endTransform;
   float endTime;
+  float fScaled;
 };
 
 class IModelManager {


### PR DESCRIPTION
Previously we would get the bones based on their index, now we get them on their name. Also fix some lerping issues between keyframes for smoother curls.