### PR TITLE
Ensure valid values when calculating bone transforms

### DIFF
--- a/include/Bones.h
+++ b/include/Bones.h
@@ -75,7 +75,7 @@ class BoneAnimator {
   static void TransformLeftBone(vr::VRBoneTransform_t& bone, const HandSkeletonBone& boneIndex);
 
  private:
-  vr::VRBoneTransform_t GetTransformForBone(const HandSkeletonBone& boneIndex, const float f, const bool rightHand) const;
+  void SetTransformForBone(vr::VRBoneTransform_t& bone, const HandSkeletonBone& boneIndex, const float f, const bool rightHand) const;
 
   std::string fileName_;
   std::unique_ptr<IModelManager> modelManager_;


### PR DESCRIPTION
Previously, we didn't have a check to make sure that the flexion values were valid before trying to use them for calculations, this change passes bones by reference, as well as checking to make sure that we actually have a value within range to use, otherwise it skips the bones, so it remains where it is.