### PR TITLE
Move approx thumb setting up and default false

### DIFF
--- a/openglove/resources/settings/default.vrsettings
+++ b/openglove/resources/settings/default.vrsettings
@@ -19,9 +19,9 @@
   {
     "__title": "Knuckles Emulation",
     "__type": "device_driver:1",
+    "approximate_thumb": false,
     "left_serial_number": "LHR-E217CD00",
-    "right_serial_number": "LHR-E217CD01",
-	"approximate_thumb": true
+    "right_serial_number": "LHR-E217CD01"
   },
   "pose_settings":
   {


### PR DESCRIPTION
Unfortunately, it appears that having thumb approximation enabled on full-tracking enabled games leads to the thumb looking jumpy, as the hand tracking in apps (like SteamVR home) seems prioritize finger positions from capacitive touch first before looking at skeletal input. This appears to happen to the index finger due to the trigger gesture as well.

Perhaps there's a way to have it automatically detect what games don't have analog thumb support and enable from there (maybe by querying a predetermined list), but that doesn't sound like a perfect solution either.

Until there's a definite solution to this, the easiest solution is to default thumb approximation to false and have people turn it on when they plan to play a game that requires index emulation. This is a setting that would really benefit from real-time updating. 

Currently, my testing platform is very laggy because I'm using Virtual Desktop over a non-local network, so it's possible that what I'm noticing is caused by lag and not actually from the approximation. I'd like to get a confirmation that this is in fact a real issue before merging this in.