### PR TITLE
Bugfix serial lag

### DIFF
--- a/src/Communication/SerialCommunicationManager.cpp
+++ b/src/Communication/SerialCommunicationManager.cpp
@@ -101,6 +101,8 @@ bool SerialCommunicationManager::ReceiveNextPacket(std::string& buff) {
   // will become saturated and block future reads. We've got the data we need so purge
   // anything else left in the buffer. There should be more data ready for us in the
   // buffer by the next time we poll for it.
+  // TODO: This is currently causing lag on ESP32's so purging has been removed for now.
+  // Things to try in the future are purging on a time increment, or shrinking the buffer size.
   //PurgeBuffer();
 
   return true;

--- a/src/Communication/SerialCommunicationManager.cpp
+++ b/src/Communication/SerialCommunicationManager.cpp
@@ -101,7 +101,7 @@ bool SerialCommunicationManager::ReceiveNextPacket(std::string& buff) {
   // will become saturated and block future reads. We've got the data we need so purge
   // anything else left in the buffer. There should be more data ready for us in the
   // buffer by the next time we poll for it.
-  PurgeBuffer();
+  //PurgeBuffer();
 
   return true;
 }


### PR DESCRIPTION
Fixes a bug observable in 0.4.2 which causes serial communication on ESP32's (cp210x) to be very laggy over USB.

This is fixed by removing the buffer purge, which may be fixed later on.