### PR TITLE
Use degrees in pose settings

### DIFF
--- a/src/Calibration.cpp
+++ b/src/Calibration.cpp
@@ -53,9 +53,9 @@ VRPoseConfiguration Calibration::CompleteCalibration(
 
   const vr::HmdVector3_t eulerOffset = QuaternionToEuler(transformQuat);
 
-  vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_x_offset_degrees" : "left_x_offset_degrees", eulerOffset.v[0]);
-  vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_y_offset_degrees" : "left_y_offset_degrees", eulerOffset.v[1]);
-  vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_z_offset_degrees" : "left_z_offset_degrees", eulerOffset.v[2]);
+  vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_x_offset_degrees" : "left_x_offset_degrees", RadToDeg(eulerOffset.v[0]));
+  vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_y_offset_degrees" : "left_y_offset_degrees", RadToDeg(eulerOffset.v[1]));
+  vr::VRSettings()->SetFloat(c_poseSettingsSection, isRightHand ? "right_z_offset_degrees" : "left_z_offset_degrees", RadToDeg(eulerOffset.v[2]));
 
   return poseConfiguration;
 }


### PR DESCRIPTION
Recently a change was made that would use radians in a quaternion to euler conversion, rather than degrees. This change broke calibration.

This pr sets the calibration settings to degrees when saving.