### PR TITLE
expanding knuckle emulation trigger behavior

### DIFF
--- a/include/DeviceConfiguration.h
+++ b/include/DeviceConfiguration.h
@@ -77,6 +77,8 @@ struct VRDeviceConfiguration {
   vr::ETrackedControllerRole role;
   bool enabled;
   bool feedbackEnabled;
+  bool useAuxTrigger; // placeholder until extra input is added
+  bool binaryTrigger; 
   VRPoseConfiguration poseConfiguration;
   VREncodingProtocol encodingProtocol;
   VRCommunicationProtocol communicationProtocol;
@@ -86,6 +88,8 @@ struct VRDeviceConfiguration {
       const vr::ETrackedControllerRole role,
       const bool enabled,
       const bool feedbackEnabled,
+      const bool useAuxTrigger,  // placeholder until extra input is added
+      const bool binaryTrigger, 
       const VRPoseConfiguration poseConfiguration,
       const VREncodingProtocol encodingProtocol,
       const VRCommunicationProtocol communicationProtocol,
@@ -93,6 +97,8 @@ struct VRDeviceConfiguration {
       : role(role),
         enabled(enabled),
         feedbackEnabled(feedbackEnabled),
+        useAuxTrigger(useAuxTrigger),
+        binaryTrigger(binaryTrigger),
         poseConfiguration(poseConfiguration),
         encodingProtocol(encodingProtocol),
         communicationProtocol(communicationProtocol),

--- a/include/DeviceConfiguration.h
+++ b/include/DeviceConfiguration.h
@@ -77,8 +77,7 @@ struct VRDeviceConfiguration {
   vr::ETrackedControllerRole role;
   bool enabled;
   bool feedbackEnabled;
-  bool useAuxTrigger; // placeholder until extra input is added
-  bool binaryTrigger; 
+  bool indexCurlTrigger; 
   VRPoseConfiguration poseConfiguration;
   VREncodingProtocol encodingProtocol;
   VRCommunicationProtocol communicationProtocol;
@@ -88,8 +87,7 @@ struct VRDeviceConfiguration {
       const vr::ETrackedControllerRole role,
       const bool enabled,
       const bool feedbackEnabled,
-      const bool useAuxTrigger,  // placeholder until extra input is added
-      const bool binaryTrigger, 
+      const bool indexCurlTrigger, 
       const VRPoseConfiguration poseConfiguration,
       const VREncodingProtocol encodingProtocol,
       const VRCommunicationProtocol communicationProtocol,
@@ -97,8 +95,7 @@ struct VRDeviceConfiguration {
       : role(role),
         enabled(enabled),
         feedbackEnabled(feedbackEnabled),
-        useAuxTrigger(useAuxTrigger),
-        binaryTrigger(binaryTrigger),
+        indexCurlTrigger(indexCurlTrigger),
         poseConfiguration(poseConfiguration),
         encodingProtocol(encodingProtocol),
         communicationProtocol(communicationProtocol),

--- a/include/Encode/EncodingManager.h
+++ b/include/Encode/EncodingManager.h
@@ -21,12 +21,13 @@ struct VRFFBData {
 struct VRInputData {
   VRInputData()
       : VRInputData(
-            {0.0f, 0.0f, 0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f, 0.0f, 0.0f}, 0.0f, 0.0f, false, false, false, false, false, false, false, false){};
+            {0.0f, 0.0f, 0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f, 0.0f, 0.0f}, 0.0f, 0.0f, 0.0f, false, false, false, false, false, false, false, false){};
 
   VRInputData(
       std::array<float, 5> flexion,
       float joyX,
       float joyY,
+      float trgValue,
       bool joyButton,
       bool trgButton,
       bool aButton,
@@ -59,6 +60,7 @@ struct VRInputData {
         }),
         joyX(joyX),
         joyY(joyY),
+        trgValue(trgValue),
         joyButton(joyButton),
         trgButton(trgButton),
         aButton(aButton),
@@ -73,6 +75,7 @@ struct VRInputData {
       std::array<float, 5> splay,
       float joyX,
       float joyY,
+      float trgValue,
       bool joyButton,
       bool trgButton,
       bool aButton,
@@ -85,6 +88,7 @@ struct VRInputData {
         splay(splay),
         joyX(joyX),
         joyY(joyY),
+        trgValue(trgValue), 
         joyButton(joyButton),
         trgButton(trgButton),
         aButton(aButton),
@@ -98,6 +102,7 @@ struct VRInputData {
   const std::array<float, 5> splay = {-2.0f, -2.0f, -2.0f, -2.0f, -2.0f};
   const float joyX;
   const float joyY;
+  const float trgValue;
   const bool joyButton;
   const bool trgButton;
   const bool aButton;

--- a/openglove/resources/settings/default.vrsettings
+++ b/openglove/resources/settings/default.vrsettings
@@ -22,7 +22,7 @@
     "left_serial_number": "LHR-E217CD00",
     "right_serial_number": "LHR-E217CD01",
 	"approximate_thumb": true,
-  "index_curl_as_trigger": false
+  "index_curl_as_trigger": true
   },
   "pose_settings":
   {

--- a/openglove/resources/settings/default.vrsettings
+++ b/openglove/resources/settings/default.vrsettings
@@ -4,7 +4,6 @@
     "left_enabled": true,
     "right_enabled": true,
     "feedback_enabled": true,
-    "index_curl_as_trigger": false, 
     "communication_protocol": 0, //title:Communication Method
     "device_driver": 1, //title:Device Driver Emulation
     "encoding_protocol": 1 //title:Encoding Protocol
@@ -22,7 +21,8 @@
     "__type": "device_driver:1",
     "left_serial_number": "LHR-E217CD00",
     "right_serial_number": "LHR-E217CD01",
-	"approximate_thumb": true
+	"approximate_thumb": true,
+  "index_curl_as_trigger": false
   },
   "pose_settings":
   {

--- a/openglove/resources/settings/default.vrsettings
+++ b/openglove/resources/settings/default.vrsettings
@@ -4,6 +4,7 @@
     "left_enabled": true,
     "right_enabled": true,
     "feedback_enabled": true,
+    "index_curl_as_trigger": false, 
     "communication_protocol": 0, //title:Communication Method
     "device_driver": 1, //title:Device Driver Emulation
     "encoding_protocol": 1 //title:Encoding Protocol

--- a/src/DeviceDriver/KnuckleDriver.cpp
+++ b/src/DeviceDriver/KnuckleDriver.cpp
@@ -22,8 +22,8 @@ void KnuckleDeviceDriver::HandleInput(const VRInputData data) {
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::ThumbstickTouch)], data.joyButton, 0);
 
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::TriggerClick)], data.trgButton, 0);
-  const float triggerValue = configuration_.binaryTrigger ? data.trgButton : boneAnimator_->GetAverageCurlValue(data.flexion[1]); // determine triggerValue, no auxiliary trigger input yet
-  vr::VRDriverInput()->UpdateScalarComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::TriggerValue)], triggerValue, 0);
+  const float triggerValue = configuration_.indexCurlTrigger ? boneAnimator_->GetAverageCurlValue(data.flexion[1]) : data.trgValue; // determine triggerValue
+  vr::VRDriverInput()->UpdateScalarComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::TriggerValue)], (data.trgButton ? 1 : triggerValue), 0); // TriggerValue always 1 on trigger button press (end of swing)
 
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::AClick)], data.aButton, 0);
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::ATouch)], data.aButton || (approximateThumb_ && boneAnimator_->GetAverageCurlValue(data.flexion[0]) > 0.6), 0); //Thumb approximation

--- a/src/DeviceDriver/KnuckleDriver.cpp
+++ b/src/DeviceDriver/KnuckleDriver.cpp
@@ -22,7 +22,8 @@ void KnuckleDeviceDriver::HandleInput(const VRInputData data) {
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::ThumbstickTouch)], data.joyButton, 0);
 
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::TriggerClick)], data.trgButton, 0);
-  vr::VRDriverInput()->UpdateScalarComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::TriggerValue)], data.trgButton, 0);
+  const float triggerValue = configuration_.binaryTrigger ? data.trgButton : boneAnimator_->GetAverageCurlValue(data.flexion[1]); // determine triggerValue, no auxiliary trigger input yet
+  vr::VRDriverInput()->UpdateScalarComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::TriggerValue)], triggerValue, 0);
 
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::AClick)], data.aButton, 0);
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::ATouch)], data.aButton || (approximateThumb_ && boneAnimator_->GetAverageCurlValue(data.flexion[0]) > 0.6), 0); //Thumb approximation

--- a/src/DeviceDriver/KnuckleDriver.cpp
+++ b/src/DeviceDriver/KnuckleDriver.cpp
@@ -22,7 +22,7 @@ void KnuckleDeviceDriver::HandleInput(const VRInputData data) {
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::ThumbstickTouch)], data.joyButton, 0);
 
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::TriggerClick)], data.trgButton, 0);
-  vr::VRDriverInput()->UpdateScalarComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::TriggerValue)], boneAnimator_->GetAverageCurlValue(data.flexion[1]), 0);
+  vr::VRDriverInput()->UpdateScalarComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::TriggerValue)], data.trgButton, 0);
 
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::AClick)], data.aButton, 0);
   vr::VRDriverInput()->UpdateBooleanComponent(inputComponentHandles_[static_cast<int>(KnuckleDeviceComponentIndex::ATouch)], data.aButton || (approximateThumb_ && boneAnimator_->GetAverageCurlValue(data.flexion[0]) > 0.6), 0); //Thumb approximation

--- a/src/DeviceProvider.cpp
+++ b/src/DeviceProvider.cpp
@@ -141,7 +141,7 @@ VRDeviceConfiguration DeviceProvider::GetDeviceConfiguration(const vr::ETrackedC
 
   const bool isEnabled = vr::VRSettings()->GetBool(c_driverSettingsSection, isRightHand ? "right_enabled" : "left_enabled");
   const bool feedbackEnabled = vr::VRSettings()->GetBool(c_driverSettingsSection, "feedback_enabled");
-  const bool indexCurlTrigger = vr::VRSettings()->GetBool(c_driverSettingsSection, "index_curl_as_trigger");
+  const bool indexCurlTrigger = vr::VRSettings()->GetBool(c_knuckleDeviceSettingsSection, "index_curl_as_trigger");
 
   const auto communicationProtocol =
       static_cast<VRCommunicationProtocol>(vr::VRSettings()->GetInt32(c_driverSettingsSection, "communication_protocol"));

--- a/src/DeviceProvider.cpp
+++ b/src/DeviceProvider.cpp
@@ -141,6 +141,8 @@ VRDeviceConfiguration DeviceProvider::GetDeviceConfiguration(const vr::ETrackedC
 
   const bool isEnabled = vr::VRSettings()->GetBool(c_driverSettingsSection, isRightHand ? "right_enabled" : "left_enabled");
   const bool feedbackEnabled = vr::VRSettings()->GetBool(c_driverSettingsSection, "feedback_enabled");
+  const bool useAuxTrigger = vr::VRSettings()->GetBool(c_driverSettingsSection, "use_auxiliary_trigger");
+  const bool binaryTrigger = vr::VRSettings()->GetBool(c_driverSettingsSection, "binary_trigger");
 
   const auto communicationProtocol =
       static_cast<VRCommunicationProtocol>(vr::VRSettings()->GetInt32(c_driverSettingsSection, "communication_protocol"));
@@ -180,6 +182,8 @@ VRDeviceConfiguration DeviceProvider::GetDeviceConfiguration(const vr::ETrackedC
       role,
       isEnabled,
       feedbackEnabled,
+      useAuxTrigger,
+      binaryTrigger,
       VRPoseConfiguration(offsetVector, angleOffsetQuaternion, poseTimeOffset, controllerOverrideEnabled, controllerIdOverride, calibrationButton),
       encodingProtocol,
       communicationProtocol,

--- a/src/DeviceProvider.cpp
+++ b/src/DeviceProvider.cpp
@@ -141,8 +141,7 @@ VRDeviceConfiguration DeviceProvider::GetDeviceConfiguration(const vr::ETrackedC
 
   const bool isEnabled = vr::VRSettings()->GetBool(c_driverSettingsSection, isRightHand ? "right_enabled" : "left_enabled");
   const bool feedbackEnabled = vr::VRSettings()->GetBool(c_driverSettingsSection, "feedback_enabled");
-  const bool useAuxTrigger = vr::VRSettings()->GetBool(c_driverSettingsSection, "use_auxiliary_trigger");
-  const bool binaryTrigger = vr::VRSettings()->GetBool(c_driverSettingsSection, "binary_trigger");
+  const bool indexCurlTrigger = vr::VRSettings()->GetBool(c_driverSettingsSection, "index_curl_as_trigger");
 
   const auto communicationProtocol =
       static_cast<VRCommunicationProtocol>(vr::VRSettings()->GetInt32(c_driverSettingsSection, "communication_protocol"));
@@ -182,8 +181,7 @@ VRDeviceConfiguration DeviceProvider::GetDeviceConfiguration(const vr::ETrackedC
       role,
       isEnabled,
       feedbackEnabled,
-      useAuxTrigger,
-      binaryTrigger,
+      indexCurlTrigger,
       VRPoseConfiguration(offsetVector, angleOffsetQuaternion, poseTimeOffset, controllerOverrideEnabled, controllerIdOverride, calibrationButton),
       encodingProtocol,
       communicationProtocol,

--- a/src/Encode/AlphaEncodingManager.cpp
+++ b/src/Encode/AlphaEncodingManager.cpp
@@ -42,6 +42,7 @@ static enum class VRCommDataAlphaEncodingKey : int {
   JoyY,
   JoyBtn,
 
+  TrgValue,
   BtnTrg,
   BtnA,
   BtnB,
@@ -52,7 +53,7 @@ static enum class VRCommDataAlphaEncodingKey : int {
   BtnMenu,
   BtnCalib,
 
-  Null,
+  Null
 };
 
 static const std::string keyCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ()";
@@ -103,7 +104,8 @@ static const std::map<std::string, VRCommDataAlphaEncodingKey> VRCommDataAlphaEn
     {"M", VRCommDataAlphaEncodingKey::GesPinch},  // pinch gesture (boolean)
     {"N", VRCommDataAlphaEncodingKey::BtnMenu},   // system button pressed (opens SteamVR menu)
     {"O", VRCommDataAlphaEncodingKey::BtnCalib},  // calibration button
-    {"", VRCommDataAlphaEncodingKey::Null},       // Junk key
+    {"P", VRCommDataAlphaEncodingKey::TrgValue},  // analog trigger value
+    {"", VRCommDataAlphaEncodingKey::Null}        // Junk key
 };
 
 static const std::map<VRCommDataAlphaEncodingKey, std::string> VRCommDataAlphaEncodingOutputKeyString{
@@ -204,11 +206,18 @@ VRInputData AlphaEncodingManager::Decode(const std::string& input) {
   if (inputMap.find(VRCommDataAlphaEncodingKey::JoyY) != inputMap.end())
     joyY = 2 * std::stof(inputMap.at(VRCommDataAlphaEncodingKey::JoyY)) / maxAnalogValue_ - 1;
 
+  float trgValue = 0; 
+
+  // trigger value is 0.0f -> 1.0f inclusive
+  if (inputMap.find(VRCommDataAlphaEncodingKey::TrgValue) != inputMap.end())
+    trgValue = std::stof(inputMap.at(VRCommDataAlphaEncodingKey::TrgValue)) / maxAnalogValue_;
+
   VRInputData inputData(
       jointFlexion,
       splay,
       joyX,
       joyY,
+      trgValue,
       inputMap.find(VRCommDataAlphaEncodingKey::JoyBtn) != inputMap.end(),
       inputMap.find(VRCommDataAlphaEncodingKey::BtnTrg) != inputMap.end(),
       inputMap.find(VRCommDataAlphaEncodingKey::BtnA) != inputMap.end(),

--- a/src/Encode/LegacyEncodingManager.cpp
+++ b/src/Encode/LegacyEncodingManager.cpp
@@ -17,6 +17,7 @@ enum class VRCommDataLegacyEncodingPosition : int {
   BtnB,
   GesGrab,
   GesPinch,
+  TrgValue,   // legacy needs to follow an order
   Max,
 };
 
@@ -41,11 +42,13 @@ VRInputData LegacyEncodingManager::Decode(const std::string& input) {
 
   const float joyX = 2 * tokens[static_cast<int>(VRCommDataLegacyEncodingPosition::JoyX)] / maxAnalogValue_ - 1;
   const float joyY = 2 * tokens[static_cast<int>(VRCommDataLegacyEncodingPosition::JoyY)] / maxAnalogValue_ - 1;
+  const float trgValue = tokens[static_cast<int>(VRCommDataLegacyEncodingPosition::TrgValue)] / maxAnalogValue_; 
 
   VRInputData inputData(
       flexion,
       joyX,
       joyY,
+      trgValue,
       tokens[static_cast<int>(VRCommDataLegacyEncodingPosition::JoyBtn)] == 1,
       tokens[static_cast<int>(VRCommDataLegacyEncodingPosition::BtnTrg)] == 1,
       tokens[static_cast<int>(VRCommDataLegacyEncodingPosition::BtnA)] == 1,

--- a/src/Encode/LegacyEncodingManager.cpp
+++ b/src/Encode/LegacyEncodingManager.cpp
@@ -17,8 +17,7 @@ enum class VRCommDataLegacyEncodingPosition : int {
   BtnB,
   GesGrab,
   GesPinch,
-  TrgValue,   // legacy needs to follow an order
-  Max,
+  Max
 };
 
 LegacyEncodingManager::LegacyEncodingManager(const float maxAnalogValue) : EncodingManager(maxAnalogValue) {}
@@ -42,7 +41,7 @@ VRInputData LegacyEncodingManager::Decode(const std::string& input) {
 
   const float joyX = 2 * tokens[static_cast<int>(VRCommDataLegacyEncodingPosition::JoyX)] / maxAnalogValue_ - 1;
   const float joyY = 2 * tokens[static_cast<int>(VRCommDataLegacyEncodingPosition::JoyY)] / maxAnalogValue_ - 1;
-  const float trgValue = tokens[static_cast<int>(VRCommDataLegacyEncodingPosition::TrgValue)] / maxAnalogValue_; 
+  const float trgValue = flexion[1];  // legacy trigger behavior for legacy encoding 
 
   VRInputData inputData(
       flexion,


### PR DESCRIPTION
dumb-dumb change to trigger behavior to alleviate some headaches in certain applications but especially overlays. 
This removes the analog trigger behavior, but what marginal benefits using your index finger as a trigger brings is outweighed by the issues of having the controller trigger constantly triggering unintentionally in most usage scenarios. 

This should be seen as a temporary feature loss until there is some consensus and solution on how to better replicate the analog trigger that doesn't make the gloves annoying to use. 