### PR TITLE
Cancel operations before attempting to join thread

### DIFF
--- a/include/Communication/CommunicationManager.h
+++ b/include/Communication/CommunicationManager.h
@@ -26,6 +26,8 @@ class CommunicationManager {
   virtual void WaitAttemptConnection();
 
   virtual bool Connect() = 0;
+
+  virtual void PrepareDisconnection(){};
   virtual bool DisconnectFromDevice() = 0;
   virtual void LogError(const char* message) = 0;
   virtual void LogMessage(const char* message) = 0;

--- a/include/Communication/SerialCommunicationManager.h
+++ b/include/Communication/SerialCommunicationManager.h
@@ -19,6 +19,8 @@ class SerialCommunicationManager : public CommunicationManager {
 
  protected:
   bool Connect() override;
+
+  void PrepareDisconnection() override;
   bool DisconnectFromDevice() override;
   void LogError(const char* message) override;
   void LogMessage(const char* message) override;

--- a/src/Communication/CommunicationManager.cpp
+++ b/src/Communication/CommunicationManager.cpp
@@ -20,9 +20,10 @@ void CommunicationManager::BeginListener(const std::function<void(VRInputData)>&
 }
 
 void CommunicationManager::Disconnect() {
-  if (threadActive_.exchange(false)) thread_.join();
-
-  if (IsConnected()) DisconnectFromDevice();
+  if (threadActive_.exchange(false)) {
+    DisconnectFromDevice();
+    thread_.join();
+  }
 }
 
 void CommunicationManager::QueueSend(const VROutput& data) {
@@ -48,7 +49,7 @@ void CommunicationManager::ListenerThread(const std::function<void(VRInputData)>
 
           SendMessageToDevice();
 
-          if(writeString_ != "\n") DriverLog("Wrote to device: %s", writeString_.c_str());
+          if (writeString_ != "\n") DriverLog("Wrote to device: %s", writeString_.c_str());
 
           writeString_.clear();
         }

--- a/src/Communication/CommunicationManager.cpp
+++ b/src/Communication/CommunicationManager.cpp
@@ -21,8 +21,14 @@ void CommunicationManager::BeginListener(const std::function<void(VRInputData)>&
 
 void CommunicationManager::Disconnect() {
   if (threadActive_.exchange(false)) {
-    DisconnectFromDevice();
+    // do anything needed to get ready to disconnect (cancelling read/write operations)
+    PrepareDisconnection();
+
+    // now wait for the thread to join
     thread_.join();
+
+    // then disconnect fully
+    DisconnectFromDevice();
   }
 }
 

--- a/src/Communication/CommunicationManager.cpp
+++ b/src/Communication/CommunicationManager.cpp
@@ -76,4 +76,9 @@ void CommunicationManager::WaitAttemptConnection() {
   while (threadActive_ && !IsConnected() && !Connect()) {
     std::this_thread::sleep_for(std::chrono::milliseconds(c_listenerWaitTime));
   }
+  if (!threadActive_) return;
+  // we're now connected
+
+  // discard anything we set beforehand
+  writeString_ = "";
 }

--- a/src/Communication/SerialCommunicationManager.cpp
+++ b/src/Communication/SerialCommunicationManager.cpp
@@ -77,21 +77,27 @@ bool SerialCommunicationManager::Connect() {
     return false;
   }
 
+  PurgeBuffer();
+
+  if (!threadActive_) return false;
+
   // If everything went fine we're connected
   isConnected_ = true;
-
-  PurgeBuffer();
 
   LogMessage("Successfully connected to device");
 
   return true;
 }
 
-bool SerialCommunicationManager::DisconnectFromDevice() {
+void SerialCommunicationManager::PrepareDisconnection() {
   // Cancel any pending read operations
-  CancelIoEx(hSerial_, nullptr);
+  if (!CancelIoEx(hSerial_, nullptr)) {
+    LogError("Error cancelling communication");
+  }
+}
 
-  if (!CloseHandle(hSerial_)) {
+bool SerialCommunicationManager::DisconnectFromDevice() {
+  if (IsConnected() && !CloseHandle(hSerial_)) {
     LogError("Error disconnecting from device");
     return false;
   }


### PR DESCRIPTION
Disconnect from device before joining the thread. This might result in a error being thrown as we now close the handle while before joining the thread, more testing might be required.